### PR TITLE
#131_ordre de l'affichage des articles dans un volume_Exposition de l…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ yarn-error.log
 ###> phpstan/phpstan ###
 phpstan.neon
 ###< phpstan/phpstan ###
+# Cache files
+/var/cache/
+/public/var/
+/.yarn/install-state.gz
+/var/log/

--- a/src/Entity/Paper.php
+++ b/src/Entity/Paper.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Attribute\Context;
 use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Serializer\Attribute\SerializedName;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 
 
@@ -447,6 +448,12 @@ class Paper implements UserOwnedInterface
     )]
     #[ApiProperty(security: "is_granted('papers_manage', object)")]
     private Collection $conflicts;
+
+    #[ORM\OneToOne(targetEntity: VolumePaperPosition::class)]
+    #[ORM\JoinColumn(name: 'PAPERID', referencedColumnName: 'PAPERID')]
+    #[ORM\JoinColumn(name: 'VID', referencedColumnName: 'VID')]
+    //#[Groups(self::PAPERS_GROUPS)]
+    private ?VolumePaperPosition $volumePaperPosition = null;
 
     public function __construct()
     {
@@ -967,4 +974,23 @@ class Paper implements UserOwnedInterface
         return $this;
     }
 
+    public function getVolumePaperPosition(): ?VolumePaperPosition
+    {
+        return $this->volumePaperPosition;
+    }
+
+    public function setVolumePaperPosition(?VolumePaperPosition $volumePaperPosition): self
+    {
+        $this->volumePaperPosition = $volumePaperPosition;
+        return $this;
+    }
+
+    /**
+     * Méthode pour exposer la position dans l'API
+     */
+    #[Groups(self::PAPERS_GROUPS)]
+    public function getPosition(): ?int
+    {
+        return $this->volumePaperPosition?->getPosition();
+    }
 }

--- a/src/Entity/VolumePaperPosition.php
+++ b/src/Entity/VolumePaperPosition.php
@@ -4,37 +4,21 @@ namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * VolumePaperPosition
- *
- * @ORM\Table(name="VOLUME_PAPER_POSITION")
- * @ORM\Entity
- */
+#[ORM\Table(name: "VOLUME_PAPER_POSITION")]
+#[ORM\Entity]
 class VolumePaperPosition
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="VID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
-     */
+    #[ORM\Column(name: "VID", type: "integer", nullable: false, options: ["unsigned" => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "NONE")]
     private $vid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="PAPERID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
-     */
+    #[ORM\Column(name: "PAPERID", type: "integer", nullable: false, options: ["unsigned" => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: "NONE")]
     private $paperid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="POSITION", type="integer", nullable=false, options={"unsigned"=true})
-     */
+    #[ORM\Column(name: "POSITION", type: "integer", nullable: false, options: ["unsigned" => true])]
     private $position;
 
     public function getVid(): ?int

--- a/src/Repository/VolumeRepository.php
+++ b/src/Repository/VolumeRepository.php
@@ -70,7 +70,22 @@ class VolumeRepository extends ServiceEntityRepository implements RangeInterface
 
     public function getCommitteeQuery(int $rvId, int $vid): string
     {
-        $sql = "SELECT uuid, CIV as `civ`, SCREEN_NAME AS `screenName`, ORCID AS `orcid` FROM ( SELECT UID, VID, `WHEN` FROM ( SELECT `ua`.* FROM `USER_ASSIGNMENT` AS `ua` INNER JOIN( SELECT `USER_ASSIGNMENT`.`ITEMID`, MAX(`WHEN`) AS `WHEN`, ITEMID as vid FROM `USER_ASSIGNMENT` WHERE (RVID = $rvId) AND (`USER_ASSIGNMENT`.`ITEMID` = $vid) AND(ITEM = 'volume') AND(ROLEID = 'editor') GROUP BY `ITEMID`, UID ) AS `r1` ON ua.ITEMID = r1.ITEMID AND ua.`WHEN` = r1.`WHEN` WHERE (RVID = $rvId) AND (ua.ITEMID = $vid) AND (ITEM = 'volume') AND(ROLEID = 'editor') AND( STATUS = 'active' ) ) AS `r2` INNER JOIN VOLUME AS v ON v.RVID = r2.RVID AND v.VID = r2.ITEMID) AS `result` INNER JOIN USER AS `u` ON result.UID = u.UID  GROUP BY VID,uuid ORDER BY u.LASTNAME ASC;";
+        $sql = "SELECT uuid, CIV as `civ`, SCREEN_NAME AS `screenName`, ORCID AS `orcid` 
+                FROM ( SELECT UID, VID, `WHEN` 
+                       FROM ( SELECT `ua`.* FROM `USER_ASSIGNMENT` AS `ua` 
+                           INNER JOIN( 
+                           SELECT `USER_ASSIGNMENT`.`ITEMID`, MAX(`WHEN`) AS `WHEN`, ITEMID as vid 
+                           FROM `USER_ASSIGNMENT` 
+                           WHERE (RVID = $rvId) AND (`USER_ASSIGNMENT`.`ITEMID` = $vid) AND(ITEM = 'volume') AND(ROLEID = 'editor') 
+                           GROUP BY `ITEMID`, UID 
+                           ) AS `r1` ON ua.ITEMID = r1.ITEMID AND ua.`WHEN` = r1.`WHEN` 
+                                            WHERE (RVID = $rvId) AND (ua.ITEMID = $vid) AND (ITEM = 'volume') AND(ROLEID = 'editor') AND( STATUS = 'active' )
+                                            ) AS `r2` 
+                           INNER JOIN VOLUME AS v ON v.RVID = r2.RVID AND v.VID = r2.ITEMID
+                       ) AS `result` 
+                    INNER JOIN USER AS `u` ON result.UID = u.UID  
+                GROUP BY VID,uuid, CIV, SCREEN_NAME, ORCID, u.LASTNAME
+                ORDER BY u.LASTNAME ASC;";
         return $sql;
 
     }


### PR DESCRIPTION
L'ordre des articles dans un volume n'était pas respecté à l'affichage, en raison de l'absence de la position dans les données fournies par l'API. L'ajout de cette information dans la réponse permet désormais un affichage correct(peut-être).