### PR TITLE
fix: Fix statistics grouping by submissionDate instead of modificatio…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,4 +34,5 @@ services:
 networks:
   epi-network:
     #external: true
-    name: episciences-gpl_epi-network
+    #name: episciences-gpl_epi-network
+    name: episciences-api_epi-network

--- a/src/Entity/PaperConflicts.php
+++ b/src/Entity/PaperConflicts.php
@@ -74,7 +74,7 @@ class PaperConflicts
     private $date = 'CURRENT_TIMESTAMP';
 
     #[ORM\ManyToOne( fetch: 'EAGER', inversedBy: 'conflicts')]
-    #[ORM\JoinColumn(name: 'paper_id', referencedColumnName: 'DOCID', nullable: true)]
+    #[ORM\JoinColumn(name: 'paper_id', referencedColumnName: 'PAPERID', nullable: true)]
     private ?Paper $papers = null;
 
     public function getCid(): ?int


### PR DESCRIPTION
 Les statistiques de papers refusés étaient groupées par modificationDate au lieu de submissionDate, causant l'apparition de 138 papers "refusés" en 2025 suite à une migration DB.