### PR TITLE
Migration PHP 8.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DOCKER_COMPOSE := $(shell if command -v docker-compose >/dev/null 2>&1; then ech
 .DEFAULT_GOAL := help
 
 # Phony targets
-.PHONY: help check-prereqs install ssl-certs ssl-clean test test-unit test-coverage cov test-file validate clean phpstan rector check docker-up docker-up-ci docker-down docker-down-ci docker-restart docker-logs docker-status docker-shell docker-mysql docker-test docker-test-coverage docker-test-unit docker-install docker-install-ci docker-composer setup-help deploy deploy-branch deploy-tag
+.PHONY: help check-prereqs install ssl-certs ssl-clean test test-unit test-coverage cov test-file validate clean phpstan rector local-rector check docker-up docker-up-ci docker-down docker-down-ci docker-restart docker-logs docker-status docker-shell docker-mysql docker-test docker-test-coverage docker-test-unit docker-install docker-install-ci docker-composer docker-composer-update setup-help deploy deploy-branch deploy-tag
 
 # Help target - displays all available commands
 help:
@@ -29,13 +29,14 @@ help:
 	@echo "  $(BOLD)ssl-certs$(NC)         Generate SSL certificates for HTTPS development"
 	@echo "  $(BOLD)ssl-clean$(NC)         Remove SSL certificates"
 	@echo ""
-	@echo "$(BLUE)Testing Commands:$(NC)"
+	@echo "$(BLUE)Testing & Analysis Commands:$(NC)"
 	@echo "  $(BOLD)test$(NC)              Run all PHPUnit tests"
 	@echo "  $(BOLD)test-unit$(NC)         Run only unit tests"
 	@echo "  $(BOLD)test-coverage$(NC)     Run tests with coverage report"
 	@echo "  $(BOLD)test-file$(NC)         Run specific test file (usage: make test-file FILE=path/to/TestFile.php)"
 	@echo "  $(BOLD)phpstan$(NC)           Run PHPStan in container (usage: make phpstan LEVEL=1 TARGET=src DRY_RUN=1)"
 	@echo "  $(BOLD)rector$(NC)            Run Rector in container (usage: make rector TARGET=src DRY_RUN=1)"
+	@echo "  $(BOLD)local-rector$(NC)      Run Rector on host (usage: make local-rector TARGET=src DRY_RUN=1)"
 	@echo "  $(BOLD)check$(NC)             Run both PHPStan and Rector"
 	@echo ""
 	@echo "$(BLUE)Utility Commands:$(NC)"
@@ -68,7 +69,7 @@ help:
 	@echo "  $(BOLD)deploy-tag$(NC)         Deploy specific tag (usage: make deploy-tag TAG=v1.0.0)"
 	@echo ""
 	@echo "$(YELLOW)Prerequisites (Local Development):$(NC)"
-	@echo "  - PHP 8.2+ (php8.2 command)"
+	@echo "  - PHP 8.3+ (php8.3 command)"
 	@echo "  - Local composer binary (./composer)"
 	@echo "  - OpenSSL (for SSL certificate generation)"
 	@echo "  - Installed dependencies (vendor/)"
@@ -84,22 +85,22 @@ help:
 check-prereqs:
 	@echo "$(BOLD)Checking Prerequisites...$(NC)"
 	@echo ""
-	@# Check PHP 8.2
-	@if ! command -v php8.2 >/dev/null 2>&1; then \
-		echo "$(RED)✗ PHP 8.2 not found$(NC)"; \
-		echo "  Install PHP 8.2:"; \
-		echo "    Ubuntu/Debian: $(BOLD)sudo apt install php8.2 php8.2-cli php8.2-mbstring php8.2-xml php8.2-mysql$(NC)"; \
+	@# Check PHP 8.3
+	@if ! command -v php8.3 >/dev/null 2>&1; then \
+		echo "$(RED)✗ PHP 8.3 not found$(NC)"; \
+		echo "  Install PHP 8.3:"; \
+		echo "    Ubuntu/Debian: $(BOLD)sudo apt install php8.3 php8.3-cli php8.3-mbstring php8.3-xml php8.3-mysql$(NC)"; \
 		echo "    CentOS/RHEL:   $(BOLD)sudo yum install php82 php82-cli php82-mbstring php82-xml php82-mysqlnd$(NC)"; \
 		echo ""; \
 		exit 1; \
 	else \
-		echo "$(GREEN)✓ PHP 8.2 found$(NC) ($$(php8.2 --version | head -n1))"; \
+		echo "$(GREEN)✓ PHP 8.3 found$(NC) ($$(php8.3 --version | head -n1))"; \
 	fi
 	@# Check local composer
 	@if [ ! -f "./composer" ]; then \
 		echo "$(RED)✗ Local composer not found$(NC)"; \
 		echo "  Download composer:"; \
-		echo "    $(BOLD)curl -sS https://getcomposer.org/installer | php8.2$(NC)"; \
+		echo "    $(BOLD)curl -sS https://getcomposer.org/installer | php8.3$(NC)"; \
 		echo "    $(BOLD)mv composer.phar composer$(NC)"; \
 		echo ""; \
 		exit 1; \
@@ -148,7 +149,7 @@ check-prereqs:
 # Install PHP dependencies
 install: check-prereqs
 	@echo "$(BOLD)Installing PHP dependencies...$(NC)"
-	php8.2 ./composer install --no-progress --prefer-dist --optimize-autoloader
+	php8.3 ./composer install --no-progress --prefer-dist --optimize-autoloader
 	@echo "$(GREEN)✓ Dependencies installed successfully$(NC)"
 
 # Generate SSL certificates for HTTPS development
@@ -212,7 +213,7 @@ test: check-prereqs
 		exit 1; \
 	fi
 	@echo "$(BOLD)Running all PHPUnit tests...$(NC)"
-	php8.2 vendor/bin/phpunit
+	php8.3 vendor/bin/phpunit
 	@echo "$(GREEN)✓ Tests completed$(NC)"
 
 # Run only unit tests
@@ -222,7 +223,7 @@ test-unit: check-prereqs
 		exit 1; \
 	fi
 	@echo "$(BOLD)Running unit tests...$(NC)"
-	php8.2 vendor/bin/phpunit tests/Unit/
+	php8.3 vendor/bin/phpunit tests/Unit/
 	@echo "$(GREEN)✓ Unit tests completed$(NC)"
 
 # Run tests with coverage
@@ -254,13 +255,13 @@ test-file: check-prereqs
 		exit 1; \
 	fi
 	@echo "$(BOLD)Running test file: $(FILE)$(NC)"
-	php8.2 vendor/bin/phpunit $(FILE)
+	php8.3 vendor/bin/phpunit $(FILE)
 	@echo "$(GREEN)✓ Test file completed$(NC)"
 
 # Validate PHP syntax of test files
 validate:
 	@echo "$(BOLD)Validating PHP syntax of test files...$(NC)"
-	@find tests/ -name "*.php" -exec php8.2 -l {} \; | grep -v "No syntax errors detected" || true
+	@find tests/ -name "*.php" -exec php8.3 -l {} \; | grep -v "No syntax errors detected" || true
 	@echo "$(GREEN)✓ PHP syntax validation completed$(NC)"
 
 # Run PHPStan in container
@@ -279,10 +280,20 @@ phpstan:
 rector:
 	@TARGET=$${TARGET:-src}; \
 	DRY_RUN_ARG=""; \
-	if [ "$${DRY_RUN}" = "1" ]; then DRY_RUN_ARG="--dry-run"; fi; \
+	if [ "$$DRY_RUN" = "1" ]; then DRY_RUN_ARG="--dry-run"; fi; \
 	echo "$(BOLD)Running Rector on $$TARGET...$(NC)"; \
 	$(DOCKER_COMPOSE) exec php vendor/bin/rector process $$TARGET $$DRY_RUN_ARG
 	@echo "$(GREEN)✓ Rector completed$(NC)"
+
+# Run Rector locally using host PHP
+# Usage: make local-rector TARGET=src DRY_RUN=1
+local-rector:
+	@TARGET=$${TARGET:-src}; \
+	DRY_RUN_ARG=""; \
+	if [ "$$DRY_RUN" = "1" ]; then DRY_RUN_ARG="--dry-run"; fi; \
+	echo "$(BOLD)Running Rector locally on $$TARGET...$(NC)"; \
+	php8.3 vendor/bin/rector process $$TARGET $$DRY_RUN_ARG
+	@echo "$(GREEN)✓ Local Rector completed$(NC)"
 
 # Run both PHPStan and Rector
 check: phpstan rector
@@ -446,12 +457,22 @@ docker-install:
 	$(DOCKER_COMPOSE) exec -u root php git config --global --add safe.directory /var/www/html || true
 	@echo "$(GREEN)✓ Dependencies installed securely with proper permissions$(NC)"
 
+# Update dependencies in container
+docker-composer-update:
+	@echo "$(BOLD)Updating dependencies inside a temporary Composer container...$(NC)"
+	docker run --rm \
+		-v $(PWD):/app \
+		-w /app \
+		-u $(shell id -u):$(shell id -g) \
+		composer:2 update --no-progress --prefer-dist --optimize-autoloader
+	@echo "$(GREEN)✓ Dependencies updated and composer.lock refreshed$(NC)"
+
 # Install dependencies optimized for CI
 docker-install-ci:
-	@echo "$(BOLD)Installing dependencies in PHP 8.2 container (CI optimized)...$(NC)"
+	@echo "$(BOLD)Installing dependencies in PHP 8.3 container (CI optimized)...$(NC)"
 	@echo "$(BLUE)Creating Symfony directories...$(NC)"
 	mkdir -p var/cache var/log
-	@echo "$(BLUE)Installing composer dependencies inside the PHP 8.2 container...$(NC)"
+	@echo "$(BLUE)Installing composer dependencies inside the PHP 8.3 container...$(NC)"
 	$(DOCKER_COMPOSE) exec -T php composer install --no-progress --prefer-dist --optimize-autoloader --classmap-authoritative --no-scripts
 	@echo "$(BLUE)Setting proper permissions on cache and log directories...$(NC)"
 	chmod -R 775 var/cache var/log || true
@@ -556,8 +577,8 @@ define deploy-logic
 		echo "  Download composer.phar first"; \
 		exit 1; \
 	fi
-	@php8.2 composer.phar install -o --no-dev --ignore-platform-reqs
-	@php8.2 composer.phar dump-env production
+	@php8.3 composer.phar install -o --no-dev --ignore-platform-reqs
+	@php8.3 composer.phar dump-env production
 	@# Build assets
 	@echo "$(BLUE)Building production assets...$(NC)"
 	@if command -v yarn >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Continuous Integration](https://github.com/CCSDForge/episciences-api/actions/workflows/ci.yml/badge.svg)](https://github.com/CCSDForge/episciences-api/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/CCSDForge/episciences-api/branch/main/graph/badge.svg)](https://codecov.io/gh/CCSDForge/episciences-api)
-[![PHP Version](https://img.shields.io/badge/php-%5E8.2-blue)](https://www.php.net/)
+[![PHP Version](https://img.shields.io/badge/php-%5E8.3-blue)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-7.0-black)](https://symfony.com/)
 [![License](https://img.shields.io/github/license/CCSDForge/episciences-api)](LICENSE)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?&logo=docker&logoColor=white)](https://www.docker.com/)
@@ -170,7 +170,7 @@ make docker-test
 # Run tests with HTML coverage (Docker)
 make docker-test-coverage # Report generated at coverage/index.html
 
-# Run tests locally (requires local PHP 8.2+ setup)
+# Run tests locally (requires local PHP 8.3+ setup)
 make test
 make test-unit          # Unit tests only
 make cov                # Local tests with coverage (requires Xdebug or PCOV)

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "minimum-stability": "stable",
     "prefer-stable": true,
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-json": "*",
@@ -51,6 +51,9 @@
         "symfony/yaml": "^7.0"
     },
     "config": {
+        "platform": {
+            "php": "8.3.30"
+        },
         "optimize-autoloader": true,
         "preferred-install": {
             "*": "dist"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e956feefaa88b4b397e2135e773c010b",
+    "content-hash": "f87b3c559fbb83f2e7a743ac58d8fc88",
     "packages": [
         {
             "name": "api-platform/core",
@@ -11944,12 +11944,15 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2",
+        "php": "^8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-json": "*",
         "ext-fileinfo": "*"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.30"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/deployVersion.sh
+++ b/deployVersion.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PHP_BIN="/usr/bin/php8.2"
+PHP_BIN="/usr/bin/php8.3"
 deployDate=$(date "+%Y-%m-%d %X %z")
 git fetch --all
 git fetch --tags

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.3-fpm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          colors="true"
          bootstrap="tests/bootstrap.php"
          cacheDirectory=".phpunit.cache"
+         displayDetailsOnPhpunitDeprecations="true"
 >
     <php>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=999999"/>

--- a/rector.php
+++ b/rector.php
@@ -14,23 +14,21 @@ return RectorConfig::configure()
         __DIR__ . '/src',
         __DIR__ . '/tests',
     ])
-    // Target PHP 8.2
-    ->withPhpSets(php82: true)
-    // Register Symfony container for advanced rules (uncomment if var/cache/dev exists)
-    // ->withSymfonyContainerXml(__DIR__ . '/var/cache/dev/App_KernelDevDebugContainer.xml')
+    // Target PHP 8.3
+    ->withPhpSets(php83: true)
+    ->withAttributesSets(symfony: true, doctrine: true)
+    ->withComposerBased(doctrine: true, symfony: true)
     ->withSets([
-        DoctrineSetList::ANNOTATIONS_TO_ATTRIBUTES,
-        SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
-        SymfonySetList::SYMFONY_70,
+        DoctrineSetList::DOCTRINE_CODE_QUALITY,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
     ])
+    // Register Symfony container for advanced rules (uncomment if var/cache/dev exists)
     ->withPreparedSets(
-        deadCode: true,
+        deadCode: false,
         codeQuality: true,
         typeDeclarations: true,
-        privatization: true,
-        instanceof: true,
-        earlyReturn: true,
-        strictBooleans: true
+        privatization: false,
+        instanceOf: true,
+        earlyReturn: false
     );

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
       "ignoreUnstable": false,
       "composerIgnorePlatformReqs": false,
       "constraints": {
-        "php": "8.2"
+        "php": "8.3"
       }
     }
   ]

--- a/src/AppConstants.php
+++ b/src/AppConstants.php
@@ -1,35 +1,37 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use App\Entity\Review;
 
 final class AppConstants
 {
-    public const MAXIMUM_ITEMS_PER_PAGE = 1000;
-    public const DEFAULT_ITEM_PER_PAGE = 30;
-    public const BASE_64 = 'base64';
-    public const DEFAULT_PRECISION = 0;
-    public const RATE_DEFAULT_PRECISION = 2;
-    public const IS_APP_ITEM = 'isAppItem';
-    public const IS_APP_COLLECTION = 'isAppCollection';
+    public const int MAXIMUM_ITEMS_PER_PAGE = 1000;
+    public const int DEFAULT_ITEM_PER_PAGE = 30;
+    public const string BASE_64 = 'base64';
+    public const int DEFAULT_PRECISION = 0;
+    public const int RATE_DEFAULT_PRECISION = 2;
+    public const string IS_APP_ITEM = 'isAppItem';
+    public const string IS_APP_COLLECTION = 'isAppCollection';
 
-    public const ORDER_ASC = 'ASC';
-    public const ORDER_DESC = 'DESC';
-    public const AVAILABLE_FILTERS = ['rvid', 'repoid', 'status', 'submissionDate', 'withDetails', 'startAfterDate', 'flag', AppConstants::YEAR_PARAM];
-    public const WITH_DETAILS = 'withDetails';
-    public const PAPER_STATUS = 'status';
-    public const PAPER_FLAG = 'flag';
-    public const START_AFTER_DATE = 'startAfterDate';
-    public const SUBMISSION_DATE = 'submissionDate';
-    public const STATS_DASHBOARD_ITEM = 'get_stats_dashboard_item';
-    public const STATS_NB_SUBMISSIONS_ITEM = 'get_stats_nb_submissions_item';
-    public const STATS_DELAY_SUBMISSION_ACCEPTANCE = 'get_delay_between_submit_and_acceptance_item';
-    public const STATS_DELAY_SUBMISSION_PUBLICATION = 'get_delay_between_submit_and_publication_item';
-    public const STATS_NB_USERS = 'get_stats_nb_users_item';
-    public const YEAR_PARAM = 'year';
-    public const FILTER_TYPE_EXACT = 'exact';
-    public const APP_CONST = [
+    public const string ORDER_ASC = 'ASC';
+    public const string ORDER_DESC = 'DESC';
+    public const array AVAILABLE_FILTERS = ['rvid', 'repoid', 'status', 'submissionDate', 'withDetails', 'startAfterDate', 'flag', AppConstants::YEAR_PARAM];
+    public const string WITH_DETAILS = 'withDetails';
+    public const string PAPER_STATUS = 'status';
+    public const string PAPER_FLAG = 'flag';
+    public const string START_AFTER_DATE = 'startAfterDate';
+    public const string SUBMISSION_DATE = 'submissionDate';
+    public const string STATS_DASHBOARD_ITEM = 'get_stats_dashboard_item';
+    public const string STATS_NB_SUBMISSIONS_ITEM = 'get_stats_nb_submissions_item';
+    public const string STATS_DELAY_SUBMISSION_ACCEPTANCE = 'get_delay_between_submit_and_acceptance_item';
+    public const string STATS_DELAY_SUBMISSION_PUBLICATION = 'get_delay_between_submit_and_publication_item';
+    public const string STATS_NB_USERS = 'get_stats_nb_users_item';
+    public const string YEAR_PARAM = 'year';
+    public const string FILTER_TYPE_EXACT = 'exact';
+    public const array APP_CONST = [
         'custom_operations' => [
             'items' => [
                 'review' => [ // the order of the elements is important

--- a/src/Controller/AppAbstractController.php
+++ b/src/Controller/AppAbstractController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 class AppAbstractController extends AbstractController

--- a/src/Controller/BoardsController.php
+++ b/src/Controller/BoardsController.php
@@ -32,11 +32,14 @@ class BoardsController extends AbstractController
         USER::ROLE_COPY_EDITOR,
         USER::ROLE_WEBMASTER
     ];
+    public function __construct(private readonly \Doctrine\ORM\EntityManagerInterface $entityManager, private readonly \Psr\Log\LoggerInterface $logger)
+    {
+    }
 
     /**
      * @throws ResourceNotFoundException
      */
-    public function __invoke(EntityManagerInterface $entityManager, LoggerInterface $logger, Request $request = null): ArrayPaginator
+    public function __invoke(Request $request = null): ArrayPaginator
     {
         $boards = [];
         $pagination = true;
@@ -45,10 +48,10 @@ class BoardsController extends AbstractController
         $maxResults = SolrConstants::SOLR_MAX_RETURNED_FACETS_RESULTS;
         $firstResult = 0;
 
-        if ($request !== null) {
+        if ($request instanceof \Symfony\Component\HttpFoundation\Request) {
             $tags = [];
-            $page = !$request->query->has('pagination') ? 1 : (int)$request->query->get('page');
-            $itemsPerPage = !$request->query->has('pagination') ? 30 : (int)$request->query->get('itemsPerPage');
+            $page = $request->query->has('pagination') ? (int)$request->query->get('page') : 1;
+            $itemsPerPage = $request->query->has('pagination') ? (int)$request->query->get('itemsPerPage') : 30;
             $pagination = !$request->query->has('pagination') || $request->query->get('pagination');
 
             $rolesByUid = [];
@@ -57,7 +60,7 @@ class BoardsController extends AbstractController
             if ($code) {
 
                 /** @var ReviewRepository $reviewRepo */
-                $reviewRepo = $entityManager->getRepository(Review::class);
+                $reviewRepo = $this->entityManager->getRepository(Review::class);
                 $journal = $reviewRepo->getJournalByIdentifier($code);
 
                 if (!$journal) {
@@ -65,7 +68,7 @@ class BoardsController extends AbstractController
                 }
                 /** @var UserRolesRepository $userRolesRepo */
 
-                $userRolesRepo = $entityManager->getRepository(UserRoles::class);
+                $userRolesRepo = $this->entityManager->getRepository(UserRoles::class);
                 $boardTags = $userRolesRepo->boardsUsersQuery($journal->getRvid())->getQuery()->getArrayResult();
 
                 if (empty($boardTags)) {
@@ -87,7 +90,7 @@ class BoardsController extends AbstractController
                 foreach ($result1 as $current1) {
 
                     if (!$current1['user']) {
-                        $logger->info(sprintf('empty user [UID = %s', $current1['uid']), [
+                        $this->logger->info(sprintf('empty user [UID = %s', $current1['uid']), [
                             'cause' => sprintf("L'identifiant a probablement été supprimé da la table %s, mais il est toujours présent dans la table %s", User::TABLE, UserRoles::TABLE),
                         ]);
 
@@ -105,11 +108,11 @@ class BoardsController extends AbstractController
 
                 try {
                     /** @var SectionRepository $sectionRepo */
-                    $sectionRepo = $entityManager->getRepository(Section::class);
+                    $sectionRepo = $this->entityManager->getRepository(Section::class);
                     $assignedSections = $sectionRepo->getAssignedSection($journal->getRvid(), $boardIdentifies);
                 } catch (Exception|\JsonException  $e) {
                     $assignedSections = [];
-                    $logger->critical($e->getMessage());
+                    $this->logger->critical($e->getMessage());
 
                 }
 
@@ -147,7 +150,7 @@ class BoardsController extends AbstractController
         }
 
         if ($pagination) {
-            $maxResults = $itemsPerPage ?? $maxResults;
+            $maxResults = $itemsPerPage;
             $firstResult = ($page - 1) * $maxResults;
         }
 

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -13,10 +13,13 @@ use Symfony\Component\HttpFoundation\Response;
 class ExportController extends AppAbstractController
 {
 
+    public function __construct(private readonly \App\Service\Export $solrSrv, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager)
+    {
+    }
     /**
      * @throws ResourceNotFoundException
      */
-    public function __invoke(Request $request, Export $solrSrv, EntityManagerInterface $entityManager): Response
+    public function __invoke(Request $request): Response
     {
         $journal = null;
         $code = (string)$request->query->get('code', '');
@@ -24,11 +27,11 @@ class ExportController extends AppAbstractController
         $docId = (int)$request->attributes->get('docid');
         $format = (string)$request->attributes->get('format');
 
-        if (!$docId) {
+        if ($docId === 0) {
             throw new ResourceNotFoundException('Oops! Required field {docid} is not provided');
         }
 
-        if (empty($format)) {
+        if ($format === '' || $format === '0') {
             throw new ResourceNotFoundException('Oops! Required field {format} is not provided');
         }
 
@@ -37,27 +40,27 @@ class ExportController extends AppAbstractController
             throw new ResourceNotFoundException($message);
         }
 
-        if ($code) {
+        if ($code !== '' && $code !== '0') {
 
-            $journal = $entityManager->getRepository(Review::class)->getJournalByIdentifier($code);
+            $journal = $this->entityManager->getRepository(Review::class)->getJournalByIdentifier($code);
             if (!$journal) {
                 throw new ResourceNotFoundException(sprintf('Oops! CSL cannot be generated: not found Journal %s', $code));
             }
 
         }
 
-        $solrSrv->setJournal($journal);
+        $this->solrSrv->setJournal($journal);
 
         if ($format === Export::JSON_FORMAT) {
 
-            $export = $entityManager->getRepository(Paper::class)->paperToJson($docId, $journal?->getRvid());
+            $export = $this->entityManager->getRepository(Paper::class)->paperToJson($docId, $journal?->getRvid());
 
         } else {
-            $export = $solrSrv->getSolrCSLByFormat($docId, $format);
+            $export = $this->solrSrv->getSolrCSLByFormat($docId, $format);
         }
 
         if (!$export) {
-            $codeMessage = $code ? sprintf(' in selected Journal {%s}', $code) : '';
+            $codeMessage = $code !== '' && $code !== '0' ? sprintf(' in selected Journal {%s}', $code) : '';
             $specificToJsonMsg = $format === Export:: JSON_FORMAT ? "article's document field is not null" : "the export format has been indexed correctly";
             throw new ResourceNotFoundException(sprintf("Oops! %s cannot be generated (first see if %s): the document %s does not exist or has not yet been published%s", strtoupper($format), $specificToJsonMsg, $docId, $codeMessage));
         }

--- a/src/Controller/FeedController.php
+++ b/src/Controller/FeedController.php
@@ -14,22 +14,25 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 class FeedController extends AbstractController
 {
+    public function __construct(private readonly \App\Service\Solr\SolrFeedService $feedService, private readonly \Doctrine\ORM\EntityManagerInterface $entityManager)
+    {
+    }
     /**
      * @throws ResourceNotFoundException
      */
-    public function __invoke(Request $request, SolrFeedService $feedService, EntityManagerInterface $entityManager): Response
+    public function __invoke(Request $request): Response
     {
         $code = (string) $request->attributes->get('code');
 
         $format = str_contains($request->getPathInfo(), '/atom/') ? 'atom' : 'rss';
 
-        $journal = $entityManager->getRepository(Review::class)->getJournalByIdentifier($code);
+        $journal = $this->entityManager->getRepository(Review::class)->getJournalByIdentifier($code);
 
         if (!$journal) {
             throw new ResourceNotFoundException(sprintf('Oops! Feed cannot be generated: not found Journal %s', $code));
         }
 
-        $feed = $feedService->setJournal($journal)->getSolrFeed($format);
+        $feed = $this->feedService->setJournal($journal)->getSolrFeed($format);
 
         return new Response($feed->export($format), Response::HTTP_OK, ['Content-Type' => 'text/xml']);
     }

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Controller/MeController.php
+++ b/src/Controller/MeController.php
@@ -9,14 +9,8 @@ use Symfony\Bundle\SecurityBundle\Security;
 class MeController
 {
 
-    private Security $security;
-    private ManagerRegistry $doctrine;
-
-    public function __construct(Security $security, ManagerRegistry $doctrine)
+    public function __construct(private readonly Security $security, private readonly ManagerRegistry $doctrine)
     {
-        $this->security = $security;
-        $this->doctrine = $doctrine;
-
     }
 
     public function __invoke()

--- a/src/Controller/PapersController.php
+++ b/src/Controller/PapersController.php
@@ -23,7 +23,7 @@ class PapersController
     public function __invoke(EntityManagerInterface $entityManager, Request $request = null): bool
     {
 
-        if ($request !== null) {
+        if ($request instanceof \Symfony\Component\HttpFoundation\Request) {
 
             if (!$request->query->has('documentId')) {
                 throw (new MissingRequestParameterException())::new('documentId', 'Request query');
@@ -33,7 +33,7 @@ class PapersController
 
             $userId = (int)$request->attributes->get('uid');
 
-            if ($userId) {
+            if ($userId !== 0) {
                 $user = $entityManager->getRepository(User::class)->findOneBy(['uid' => $userId]);
                 /** @var Paper $currentPaper */
                 $currentPaper = $entityManager->getRepository(Paper::class)->findOneBy(['docid' => $documentId]);

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -10,10 +10,8 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class AppFixtures extends Fixture
 {
-    private UserPasswordHasherInterface $passwordHasher;
-
-    public function __construct(UserPasswordHasherInterface $passwordHasher){
-        $this->passwordHasher = $passwordHasher;
+    public function __construct(private readonly UserPasswordHasherInterface $passwordHasher)
+    {
     }
 
     public function load(ObjectManager $manager): void

--- a/src/DataProvider/AbstractDataProvider.php
+++ b/src/DataProvider/AbstractDataProvider.php
@@ -37,7 +37,7 @@ abstract class AbstractDataProvider
 
             $journal = $this->statsService->getJournal($context['uri_variables']);
 
-            if (!$journal) {
+            if (!$journal instanceof \App\Entity\Review) {
                 throw new ResourceNotFoundException(sprintf('Oops! not found Journal %s', $context['uri_variables']['code']));
             }
 

--- a/src/DataProvider/PapersStatsDataProvider.php
+++ b/src/DataProvider/PapersStatsDataProvider.php
@@ -15,7 +15,7 @@ final class PapersStatsDataProvider extends AbstractDataProvider implements Prov
     public function supports(Operation $operation = null): bool
     {
         return (
-            $operation &&
+            $operation instanceof \ApiPlatform\Metadata\Operation &&
             (Paper::class === $operation->getClass()) &&
             in_array($operation->getName(), AppConstants::APP_CONST['custom_operations']['items']['papers'], true)
         );

--- a/src/DataProvider/ReviewStatsDataProvider.php
+++ b/src/DataProvider/ReviewStatsDataProvider.php
@@ -13,13 +13,13 @@ use App\Entity\Review;
 final class ReviewStatsDataProvider extends AbstractDataProvider implements ProviderInterface
 {
 
-    public const AVAILABLE_FILTERS = [AppConstants::START_AFTER_DATE, AppConstants::WITH_DETAILS, AppConstants::YEAR_PARAM];
+    public const array AVAILABLE_FILTERS = [AppConstants::START_AFTER_DATE, AppConstants::WITH_DETAILS, AppConstants::YEAR_PARAM];
 
 
     public function supports(Operation $operation = null): bool
     {
         return (
-            $operation &&
+            $operation instanceof \ApiPlatform\Metadata\Operation &&
             (Review::class === $operation->getClass()) &&
             in_array($operation->getName(), AppConstants::APP_CONST['custom_operations']['items']['review'], true)
         );

--- a/src/DataProvider/UsersStatsDataProvider.php
+++ b/src/DataProvider/UsersStatsDataProvider.php
@@ -16,7 +16,7 @@ final class UsersStatsDataProvider extends AbstractDataProvider implements Provi
     public function supports(Operation $operation = null): bool
     {
         return (
-            $operation &&
+            $operation instanceof \ApiPlatform\Metadata\Operation &&
             (User::class === $operation->getClass()) &&
             in_array($operation->getName(), AppConstants::APP_CONST['custom_operations']['items']['review'], true)
         );

--- a/src/Doctrine/AppQueryItemCollectionExtension.php
+++ b/src/Doctrine/AppQueryItemCollectionExtension.php
@@ -28,11 +28,8 @@ class AppQueryItemCollectionExtension implements QueryItemExtensionInterface, Qu
 {
     use QueryTrait;
 
-    private Security $security;
-
-    public function __construct(Security $security)
+    public function __construct(private Security $security)
     {
-        $this->security = $security;
     }
 
     /**
@@ -209,7 +206,7 @@ class AppQueryItemCollectionExtension implements QueryItemExtensionInterface, Qu
         $operation = $context['operation'] ?? null;
         $operationName = $operation?->getName();
 
-        if ($resourceClass === Paper::class || $resourceClass === Volume::class || $resourceClass === Section::class) {
+        if (in_array($resourceClass, [Paper::class, Volume::class, Section::class], true)) {
             if ($resourceClass === Paper::class) {
                 $allowBrowseAcceptedDocuments = isset($context[ReviewSetting::ALLOW_BROWSE_ACCEPTED_ARTICLE]) && filter_var($context[ReviewSetting::ALLOW_BROWSE_ACCEPTED_ARTICLE], FILTER_VALIDATE_BOOLEAN);
                 $isOnlyAccepted = isset($context['filters']['only_accepted']) && filter_var($context['filters']['only_accepted'], FILTER_VALIDATE_BOOLEAN);
@@ -251,7 +248,7 @@ class AppQueryItemCollectionExtension implements QueryItemExtensionInterface, Qu
         string        $resourceClass,
         User          $currentUser,
         HttpOperation $operation = null,
-                      $context = []
+                      array $context = []
     ): void
     {
         $isOnlyAccepted = isset($context['filters']['only_accepted']) && filter_var($context['filters']['only_accepted'], FILTER_VALIDATE_BOOLEAN);
@@ -309,10 +306,10 @@ class AppQueryItemCollectionExtension implements QueryItemExtensionInterface, Qu
             if ($this->security->isGranted('ROLE_EDITOR')) {
 
                 if (
-                    $operation &&
+                    $operation instanceof \ApiPlatform\Metadata\HttpOperation &&
                     (
-                        str_starts_with($operation->getUriTemplate(), Volume::DEFAULT_URI_TEMPLATE) ||
-                        str_starts_with($operation->getUriTemplate(), Section::DEFAULT_URI_TEMPLATE)
+                        str_starts_with((string) $operation->getUriTemplate(), Volume::DEFAULT_URI_TEMPLATE) ||
+                        str_starts_with((string) $operation->getUriTemplate(), Section::DEFAULT_URI_TEMPLATE)
                     )
                 ) {
 

--- a/src/Entity/AbstractVolumeSection.php
+++ b/src/Entity/AbstractVolumeSection.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Traits\ToolsTrait;
+use Doctrine\Common\Collections\Collection;
 
 abstract class AbstractVolumeSection
 {
@@ -41,6 +42,8 @@ abstract class AbstractVolumeSection
     {
         return $this->totalPublishedArticles;
     }
+
+    abstract public function getPapers(): Collection;
 
     /**
      * @return AbstractVolumeSection

--- a/src/Entity/Authors.php
+++ b/src/Entity/Authors.php
@@ -6,48 +6,30 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Authors
- *
- * @ORM\Table(name="AUTHORS")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'AUTHORS')]
 class Authors
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="ID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="FIRSTNAME", type="string", length=255, nullable=false)
-     */
-    private $firstname;
+    #[ORM\Column(name: 'FIRSTNAME', type: 'string', length: 255, nullable: false)]
+    private ?string $firstname = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="LASTNAME", type="string", length=255, nullable=false)
-     */
-    private $lastname;
+    #[ORM\Column(name: 'LASTNAME', type: 'string', length: 255, nullable: false)]
+    private ?string $lastname = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ORCID", type="string", length=255, nullable=false)
-     */
-    private $orcid;
+    #[ORM\Column(name: 'ORCID', type: 'string', length: 255, nullable: false)]
+    private ?string $orcid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="UID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $uid;
+    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $uid = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/DoiQueue.php
+++ b/src/Entity/DoiQueue.php
@@ -6,48 +6,36 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * DoiQueue
- *
- * @ORM\Table(name="doi_queue", uniqueConstraints={@ORM\UniqueConstraint(name="paperid", columns={"paperid"})}, indexes={@ORM\Index(name="doi_status", columns={"doi_status"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'doi_queue')]
+#[ORM\Index(name: 'doi_status', columns: ['doi_status'])]
+#[ORM\UniqueConstraint(name: 'paperid', columns: ['paperid'])]
 class DoiQueue
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="id_doi_queue", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'id_doi_queue', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $idDoiQueue;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="paperid", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $paperid;
+    #[ORM\Column(name: 'paperid', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $paperid = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="doi_status", type="string", length=0, nullable=false, options={"default"="assigned"})
-     */
-    private $doiStatus = 'assigned';
+    #[ORM\Column(name: 'doi_status', type: 'string', length: 0, nullable: false, options: ['default' => 'assigned'])]
+    private string $doiStatus = 'assigned';
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="date_init", type="datetime", nullable=false)
-     */
-    private $dateInit;
+    #[ORM\Column(name: 'date_init', type: 'datetime', nullable: false)]
+    private ?\DateTimeInterface $dateInit = null;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="date_updated", type="datetime", nullable=false, options={"default"="CURRENT_TIMESTAMP"})
-     */
-    private $dateUpdated = 'CURRENT_TIMESTAMP';
+    #[ORM\Column(name: 'date_updated', type: 'datetime', nullable: false)]
+    private \DateTime|\DateTimeInterface $dateUpdated;
+    public function __construct()
+    {
+        $this->dateUpdated = new \DateTime('CURRENT_TIMESTAMP');
+    }
 
     public function getIdDoiQueue(): ?int
     {

--- a/src/Entity/EntityIdentifierInterface.php
+++ b/src/Entity/EntityIdentifierInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 interface EntityIdentifierInterface

--- a/src/Entity/JournalSettingNg.php
+++ b/src/Entity/JournalSettingNg.php
@@ -183,22 +183,23 @@ class JournalSettingNg
 {
     public const TABLE = 'JOURNAL_SETTING';
 
-    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[ApiProperty(identifier: false)]
     private int $id;
 
-    #[ORM\Column(name: 'RVID', type: 'integer', unique: true)]
-    private ?int $rvid = null;
-    #[ORM\Column(name: 'SETTING', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, unique: true)]
+    private int $rvid;
+
+    #[ORM\Column(name: 'SETTING', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     private array $settings;
 
-    #[ORM\Column(name: 'CREATED_AT', type: 'datetime', nullable: true, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    #[ORM\Column(name: 'CREATED_AT', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private ?\DateTimeInterface $createdAt = null;
 
 
-    #[ORM\Column(name: 'UPDATED_AT', type: 'datetime', nullable: true, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    #[ORM\Column(name: 'UPDATED_AT', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private ?\DateTimeInterface $updatedAt = null;
 
 
@@ -217,6 +218,17 @@ class JournalSettingNg
     public function setId(int $id): self
     {
         $this->id = $id;
+        return $this;
+    }
+
+    public function getRvid(): int
+    {
+        return $this->rvid;
+    }
+
+    public function setRvid(int $rvid): self
+    {
+        $this->rvid = $rvid;
         return $this;
     }
 

--- a/src/Entity/LegacyNews.php
+++ b/src/Entity/LegacyNews.php
@@ -6,55 +6,38 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * News
- *
- * @ORM\Table(name="NEWS", indexes={@ORM\Index(name="RVID", columns={"RVID"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'NEWS')]
+#[ORM\Index(name: 'RVID', columns: ['RVID'])]
 class LegacyNews
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="NEWSID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'NEWSID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $newsid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $rvid;
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $rvid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="UID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $uid;
+    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $uid = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="LINK", type="string", length=2000, nullable=false)
-     */
-    private $link;
+    #[ORM\Column(name: 'LINK', type: 'string', length: 2000, nullable: false)]
+    private ?string $link = null;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="ONLINE", type="boolean", nullable=false)
-     */
-    private $online;
+    #[ORM\Column(name: 'ONLINE', type: 'boolean', nullable: false)]
+    private ?bool $online = null;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="DATE_POST", type="datetime", nullable=false, options={"default"="CURRENT_TIMESTAMP"})
-     */
-    private $datePost = 'CURRENT_TIMESTAMP';
+    #[ORM\Column(name: 'DATE_POST', type: 'datetime', nullable: false)]
+    private \DateTime|\DateTimeInterface $datePost;
+    public function __construct()
+    {
+        $this->datePost = new \DateTime('CURRENT_TIMESTAMP');
+    }
 
     public function getNewsid(): ?int
     {

--- a/src/Entity/MailLog.php
+++ b/src/Entity/MailLog.php
@@ -6,97 +6,51 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * MailLog
- *
- * @ORM\Table(name="MAIL_LOG")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'MAIL_LOG')]
 class MailLog
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="ID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $rvid;
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $rvid = null;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=true, options={"unsigned"=true})
-     */
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $docid = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="FROM", type="string", length=250, nullable=true)
-     */
-    private $from;
+    #[ORM\Column(name: 'FROM', type: 'string', length: 250, nullable: true)]
+    private ?string $from = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="REPLYTO", type="string", length=250, nullable=true)
-     */
-    private $replyto;
+    #[ORM\Column(name: 'REPLYTO', type: 'string', length: 250, nullable: true)]
+    private ?string $replyto = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TO", type="text", length=16777215, nullable=false)
-     */
-    private $to;
+    #[ORM\Column(name: 'TO', type: 'text', length: 16777215, nullable: false)]
+    private ?string $to = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="CC", type="text", length=65535, nullable=true)
-     */
-    private $cc;
+    #[ORM\Column(name: 'CC', type: 'text', length: 65535, nullable: true)]
+    private ?string $cc = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="BCC", type="text", length=65535, nullable=true)
-     */
-    private $bcc;
+    #[ORM\Column(name: 'BCC', type: 'text', length: 65535, nullable: true)]
+    private ?string $bcc = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="SUBJECT", type="string", length=250, nullable=true)
-     */
-    private $subject;
+    #[ORM\Column(name: 'SUBJECT', type: 'string', length: 250, nullable: true)]
+    private ?string $subject = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="CONTENT", type="text", length=16777215, nullable=true)
-     */
-    private $content;
+    #[ORM\Column(name: 'CONTENT', type: 'text', length: 16777215, nullable: true)]
+    private ?string $content = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="FILES", type="text", length=16777215, nullable=true)
-     */
-    private $files;
+    #[ORM\Column(name: 'FILES', type: 'text', length: 16777215, nullable: true)]
+    private ?string $files = null;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="WHEN", type="datetime", nullable=false)
-     */
-    private $when;
+    #[ORM\Column(name: 'WHEN', type: 'datetime', nullable: false)]
+    private ?\DateTimeInterface $when = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/MailTemplate.php
+++ b/src/Entity/MailTemplate.php
@@ -6,62 +6,39 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * MailTemplate
- *
- * @ORM\Table(name="MAIL_TEMPLATE", indexes={@ORM\Index(name="KEY", columns={"KEY"}), @ORM\Index(name="RVCODE", columns={"RVCODE"}), @ORM\Index(name="RVID", columns={"RVID"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'MAIL_TEMPLATE')]
+#[ORM\Index(name: 'KEY', columns: ['KEY'])]
+#[ORM\Index(name: 'RVCODE', columns: ['RVCODE'])]
+#[ORM\Index(name: 'RVID', columns: ['RVID'])]
 class MailTemplate
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="ID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="PARENTID", type="integer", nullable=true, options={"unsigned"=true})
-     */
-    private $parentid;
+    #[ORM\Column(name: 'PARENTID', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $parentid = null;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=true, options={"unsigned"=true})
-     */
-    private $rvid;
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $rvid = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="RVCODE", type="string", length=25, nullable=true)
-     */
-    private $rvcode;
+    #[ORM\Column(name: 'RVCODE', type: 'string', length: 25, nullable: true)]
+    private ?string $rvcode = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="KEY", type="string", length=255, nullable=false)
-     */
-    private $key;
+    #[ORM\Column(name: 'KEY', type: 'string', length: 255, nullable: false)]
+    private ?string $key = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TYPE", type="string", length=255, nullable=false)
-     */
-    private $type;
+    #[ORM\Column(name: 'TYPE', type: 'string', length: 255, nullable: false)]
+    private ?string $type = null;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="POSITION", type="integer", nullable=true, options={"unsigned"=true})
-     */
-    private $position;
+    #[ORM\Column(name: 'POSITION', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $position = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/MetadataSources.php
+++ b/src/Entity/MetadataSources.php
@@ -17,7 +17,7 @@ class MetadataSources
     /**
      * @var int
      */
-    #[ORM\Column(name: 'id', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'id', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
@@ -25,55 +25,55 @@ class MetadataSources
     /**
      * @var string
      */
-    #[ORM\Column(name: 'name', type: 'string', length: 255, nullable: false)]
+    #[ORM\Column(name: 'name', type: \Doctrine\DBAL\Types\Types::STRING, length: 255, nullable: false)]
     private string $name;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'type', type: 'string', length: 0, nullable: false)]
+    #[ORM\Column(name: 'type', type: \Doctrine\DBAL\Types\Types::STRING, length: 0, nullable: false)]
     private string $type;
 
     /**
      * @var bool
      */
-    #[ORM\Column(name: 'status', type: 'boolean', nullable: false, options: ['default' => '1', 'comment' => 'enabled by default'])]
+    #[ORM\Column(name: 'status', type: \Doctrine\DBAL\Types\Types::BOOLEAN, nullable: false, options: ['default' => '1', 'comment' => 'enabled by default'])]
     private bool $status = true;
 
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'identifier', type: 'string', length: 50, nullable: true, options: ['comment' => 'OAI identifier'])]
-    private ?string $identifier;
+    #[ORM\Column(name: 'identifier', type: \Doctrine\DBAL\Types\Types::STRING, length: 50, nullable: true, options: ['comment' => 'OAI identifier'])]
+    private ?string $identifier = null;
 
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'base_url', type: 'string', length: 100, nullable: true, options: ['comment' => 'OAI base url'])]
-    private ?string $baseUrl;
+    #[ORM\Column(name: 'base_url', type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: true, options: ['comment' => 'OAI base url'])]
+    private ?string $baseUrl = null;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'doi_prefix', type: 'string', length: 10, nullable: false)]
+    #[ORM\Column(name: 'doi_prefix', type: \Doctrine\DBAL\Types\Types::STRING, length: 10, nullable: false)]
     private string $doiPrefix;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'api_url', type: 'string', length: 100, nullable: false)]
+    #[ORM\Column(name: 'api_url', type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: false)]
     private string $apiUrl;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'doc_url', type: 'string', length: 150, nullable: false, options: ['comment' => "See the document's page on"])]
+    #[ORM\Column(name: 'doc_url', type: \Doctrine\DBAL\Types\Types::STRING, length: 150, nullable: false, options: ['comment' => "See the document's page on"])]
     private string $docUrl;
 
     /**
      * @var string
      */
-    #[ORM\Column(name: 'paper_url', type: 'string', length: 100, nullable: false, options: ['comment' => 'PDF'])]
+    #[ORM\Column(name: 'paper_url', type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: false, options: ['comment' => 'PDF'])]
     private string $paperUrl;
 
     public function getId(): int

--- a/src/Entity/News.php
+++ b/src/Entity/News.php
@@ -125,16 +125,16 @@ class News
     )]
     private ?string $rvcode = null;
 
-    #[ORM\Column(name: 'uid', type: 'integer', nullable: false)]
+    #[ORM\Column(name: 'uid', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false)]
     private ?int $uid = null;
 
-    #[ORM\Column(name: 'title', type: 'json', nullable: false, options: ['comment' => 'Page title'])]
+    #[ORM\Column(name: 'title', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false, options: ['comment' => 'Page title'])]
     #[groups(
         ['read:News', 'read:News:Collection']
     )]
     private array $title = [];
 
-    #[ORM\Column(name: 'content', type: 'json', nullable: true)]
+    #[ORM\Column(name: 'content', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     #[groups(
         ['read:News', 'read:News:Collection']
     )]

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -87,7 +87,7 @@ class Page
     private int $id;
 
 
-    #[ORM\Column(name: 'uid', type: 'integer', nullable: false)]
+    #[ORM\Column(name: 'uid', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false)]
     private int $uid;
 
 
@@ -104,19 +104,19 @@ class Page
     )]
     private string $rvcode;
 
-    #[ORM\Column(name: 'title', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'title', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     #[groups(
         ['read:Page', 'read:Pages']
     )]
     private array $title = [];
 
-    #[ORM\Column(name: 'content', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'content', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     #[groups(
         ['read:Page', 'read:Pages']
     )]
     private array $content = [];
 
-    #[ORM\Column(name: 'visibility', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'visibility', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     #[groups(
         ['read:Page']
     )]

--- a/src/Entity/Paper.php
+++ b/src/Entity/Paper.php
@@ -275,7 +275,7 @@ class Paper implements UserOwnedInterface
         AppConstants::APP_CONST['normalizationContext']['groups']['volume']['collection']['read'][0]
     ];
 
-    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'DOCID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     //#[ApiProperty(security: "is_granted('papers_manage', object)")]
@@ -287,39 +287,39 @@ class Paper implements UserOwnedInterface
     private int $docid;
 
 
-    #[ORM\Column(name: 'PAPERID', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'PAPERID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: true, options: ['unsigned' => true])]
     #[groups(self::PAPERS_GROUPS)]
-    private ?int $paperid;
+    private ?int $paperid = null;
 
-    #[ORM\Column(name: 'TYPE', type: 'json', nullable: true)]
+    #[ORM\Column(name: 'TYPE', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     private array $type;
 
-    #[ORM\Column(name: 'DOI', type: 'string', length: 250, nullable: true)]
+    #[ORM\Column(name: 'DOI', type: \Doctrine\DBAL\Types\Types::STRING, length: 250, nullable: true)]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0],
         ]
     )]
-    private ?string $doi;
+    private ?string $doi = null;
 
 
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $rvid;
 
 
-    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'VID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $vid = 0;
 
 
-    #[ORM\Column(name: 'SID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'SID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $sid = 0;
 
 
-    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $uid;
 
 
-    #[ORM\Column(name: 'STATUS', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'STATUS', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     /** /!\
      * Le Chargement Partiel des Données : Lorsque `fetch_partial: true` est activé
      * (généralement dans la configuration de l'eager loading d'API Platform, par exemple, en fonction des groupes de sérialisation),
@@ -340,21 +340,21 @@ class Paper implements UserOwnedInterface
     private int $status = 0;
 
 
-    #[ORM\Column(name: 'IDENTIFIER', type: 'string', length: 500, nullable: false)]
+    #[ORM\Column(name: 'IDENTIFIER', type: \Doctrine\DBAL\Types\Types::STRING, length: 500, nullable: false)]
     private string $identifier;
 
 
-    #[ORM\Column(name: 'VERSION', type: 'float', precision: 10, scale: 0, nullable: false, options: ['default' => 1])]
-    private $version = 1;
+    #[ORM\Column(name: 'VERSION', type: \Doctrine\DBAL\Types\Types::FLOAT, precision: 10, scale: 0, nullable: false, options: ['default' => 1])]
+    private float $version = 1;
 
 
-    #[ORM\Column(name: 'REPOID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'REPOID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $repoid;
 
 
-    #[ORM\Column(name: 'RECORD', type: 'text', length: 65535, nullable: false)]
+    #[ORM\Column(name: 'RECORD', type: \Doctrine\DBAL\Types\Types::TEXT, length: 65535, nullable: false)]
     private string $record;
-    #[ORM\Column(name: 'DOCUMENT', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'DOCUMENT', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     //#[groups(self::PAPERS_GROUPS)]
 
     #[groups(
@@ -363,32 +363,32 @@ class Paper implements UserOwnedInterface
         ]
     )]
     private array $document;
-    #[ORM\Column(name: 'CONCEPT_IDENTIFIER', type: 'string', length: 500, nullable: true, options: ['comment' => 'This identifier represents all versions'])]
-    private ?string $conceptIdentifier;
+    #[ORM\Column(name: 'CONCEPT_IDENTIFIER', type: \Doctrine\DBAL\Types\Types::STRING, length: 500, nullable: true, options: ['comment' => 'This identifier represents all versions'])]
+    private ?string $conceptIdentifier = null;
 
-    #[ORM\Column(name: 'FLAG', type: 'string', length: 0, nullable: false, options: ['default' => 'submitted'])]
+    #[ORM\Column(name: 'FLAG', type: \Doctrine\DBAL\Types\Types::STRING, length: 0, nullable: false, options: ['default' => 'submitted'])]
     #[ApiProperty(security: "is_granted('papers_manage', object)")]
     private string $flag = 'submitted';
 
 
-    #[ORM\Column(name: 'WHEN', type: 'datetime', nullable: false)]
+    #[ORM\Column(name: 'WHEN', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
     private DateTime $when;
 
 
-    #[ORM\Column(name: 'SUBMISSION_DATE', type: 'datetime', nullable: false)]
+    #[ORM\Column(name: 'SUBMISSION_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
     private DateTime $submissionDate;
 
 
-    #[ORM\Column(name: 'MODIFICATION_DATE', type: 'datetime', nullable: true)]
+    #[ORM\Column(name: 'MODIFICATION_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true)]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private ?DateTime $modificationDate;
+    private ?DateTime $modificationDate = null;
 
 
-    #[ORM\Column(name: 'PUBLICATION_DATE', type: 'datetime', nullable: true)]
+    #[ORM\Column(name: 'PUBLICATION_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true)]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private ?DateTime $publicationDate;
+    private ?DateTime $publicationDate = null;
 
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'papers')]
@@ -786,7 +786,7 @@ class Paper implements UserOwnedInterface
     public function getEditors(): array
     {
 
-        if (empty($this->editors)) {
+        if ($this->editors === []) {
             $this->assignmentsProcess();
         }
 
@@ -809,7 +809,7 @@ class Paper implements UserOwnedInterface
      */
     public function getReviewers(): array
     {
-        if (empty($this->reviewers)) {
+        if ($this->reviewers === []) {
             $this->assignmentsProcess();
         }
 
@@ -864,7 +864,7 @@ class Paper implements UserOwnedInterface
      */
     public function getCopyEditors(): array
     {
-        if (empty($this->copyEditors)) {
+        if ($this->copyEditors === []) {
             $this->assignmentsProcess();
         }
 
@@ -886,7 +886,7 @@ class Paper implements UserOwnedInterface
      */
     public function getCoAuthors(): array
     {
-        if (empty($this->coAuthors)) {
+        if ($this->coAuthors === []) {
             $this->assignmentsProcess();
         }
 
@@ -947,7 +947,7 @@ class Paper implements UserOwnedInterface
             }
         }
 
-        if (!empty($conflicts)) {
+        if ($conflicts !== []) {
             $this->conflicts = new ArrayCollection($conflicts);
         }
 
@@ -1003,7 +1003,7 @@ class Paper implements UserOwnedInterface
     {
         try {
             return $this->volumePaperPosition?->getPosition();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
     }

--- a/src/Entity/PaperAuthors.php
+++ b/src/Entity/PaperAuthors.php
@@ -6,51 +6,35 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperAuthors
- *
- * @ORM\Table(name="PAPER_AUTHORS", indexes={@ORM\Index(name="PAPER_AUTHOR", columns={"AUTHORID"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'PAPER_AUTHORS')]
+#[ORM\Index(name: 'PAPER_AUTHOR', columns: ['AUTHORID'])]
 class PaperAuthors
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="ID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $docid = null;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="UID", type="integer", nullable=false, options={"unsigned"=true})
      */
+    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
     private $uid = '0';
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="POSITION", type="integer", nullable=true, options={"unsigned"=true,"comment"="Classement des auteurs"})
-     */
-    private $position;
+    #[ORM\Column(name: 'POSITION', type: 'integer', nullable: true, options: ['unsigned' => true, 'comment' => 'Classement des auteurs'])]
+    private ?int $position = null;
 
-    /**
-     * @var \Authors
-     *
-     * @ORM\ManyToOne(targetEntity="Authors")
-     * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="AUTHORID", referencedColumnName="ID")
-     * })
-     */
-    private $authorid;
+    #[ORM\ManyToOne(targetEntity: Authors::class)]
+    #[ORM\JoinColumn(name: 'AUTHORID', referencedColumnName: 'ID')]
+    private ?\App\Entity\Authors $authorid = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/PaperComments.php
+++ b/src/Entity/PaperComments.php
@@ -6,83 +6,49 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperComments
- *
- * @ORM\Table(name="PAPER_COMMENTS", indexes={@ORM\Index(name="DOCID", columns={"DOCID"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'PAPER_COMMENTS')]
+#[ORM\Index(name: 'DOCID', columns: ['DOCID'])]
 class PaperComments
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="PCID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'PCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $pcid;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="PARENTID", type="integer", nullable=true, options={"unsigned"=true})
-     */
-    private $parentid;
+    #[ORM\Column(name: 'PARENTID', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $parentid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="TYPE", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $type;
+    #[ORM\Column(name: 'TYPE', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $type = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $docid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="UID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $uid;
+    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $uid = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="MESSAGE", type="text", length=16777215, nullable=true)
-     */
-    private $message;
+    #[ORM\Column(name: 'MESSAGE', type: 'text', length: 16777215, nullable: true)]
+    private ?string $message = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="FILE", type="string", length=200, nullable=true)
-     */
-    private $file;
+    #[ORM\Column(name: 'FILE', type: 'string', length: 200, nullable: true)]
+    private ?string $file = null;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="WHEN", type="datetime", nullable=false)
-     */
-    private $when;
+    #[ORM\Column(name: 'WHEN', type: 'datetime', nullable: false)]
+    private ?\DateTimeInterface $when = null;
 
     /**
      * @var \DateTime|null
-     *
-     * @ORM\Column(name="DEADLINE", type="date", nullable=true)
      */
-    private $deadline;
+    #[ORM\Column(name: 'DEADLINE', type: 'date', nullable: true)]
+    private ?\DateTimeInterface $deadline = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="OPTIONS", type="text", length=65535, nullable=true)
-     */
-    private $options;
+    #[ORM\Column(name: 'OPTIONS', type: 'text', length: 65535, nullable: true)]
+    private ?string $options = null;
 
     public function getPcid(): ?int
     {

--- a/src/Entity/PaperConflicts.php
+++ b/src/Entity/PaperConflicts.php
@@ -22,12 +22,12 @@ class PaperConflicts
         'later' => 'later'
     ];
 
-    #[ORM\Column(name: 'cid', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'cid', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private int $cid;
 
-    #[ORM\Column(name: 'paper_id', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'paper_id', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
@@ -36,7 +36,7 @@ class PaperConflicts
     )]
     private int $paperId;
 
-    #[ORM\Column(name: 'by', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'by', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
@@ -46,7 +46,7 @@ class PaperConflicts
     private int $by;
 
 
-    #[ORM\Column(name: 'answer', type: 'string', length: 0, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'answer', type: \Doctrine\DBAL\Types\Types::STRING, length: 0, options: ['unsigned' => true])]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
@@ -55,23 +55,23 @@ class PaperConflicts
     )]
     private string $answer;
 
-    #[ORM\Column(name: 'message', type: 'text', length: 65535, nullable: true)]
+    #[ORM\Column(name: 'message', type: \Doctrine\DBAL\Types\Types::TEXT, length: 65535, nullable: true)]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
         ]
     )]
-    private $message;
+    private ?string $message = null;
 
-    #[ORM\Column(name: 'date', type: 'datetime', nullable: false, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    #[ORM\Column(name: 'date', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false, options: ['default' => 'CURRENT_TIMESTAMP'])]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
         ]
     )]
-    private $date = 'CURRENT_TIMESTAMP';
+    private ?\DateTimeInterface $date = null;
 
     #[ORM\ManyToOne( fetch: 'EAGER', inversedBy: 'conflicts')]
     #[ORM\JoinColumn(name: 'paper_id', referencedColumnName: 'PAPERID', nullable: true)]

--- a/src/Entity/PaperDatasets.php
+++ b/src/Entity/PaperDatasets.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use DateTime;
@@ -7,69 +9,66 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperDatasets
- *
- * @ORM\Table(name="paper_datasets", uniqueConstraints={@ORM\UniqueConstraint(name="unique", columns={"doc_id", "code", "name", "value", "source_id"})}, indexes={@ORM\Index(name="code", columns={"code"}), @ORM\Index(name="doc_id", columns={"doc_id"}), @ORM\Index(name="name", columns={"name"}), @ORM\Index(name="source_id", columns={"source_id"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'paper_datasets')]
+#[ORM\Index(name: 'code', columns: ['code'])]
+#[ORM\Index(name: 'doc_id', columns: ['doc_id'])]
+#[ORM\Index(name: 'name', columns: ['name'])]
+#[ORM\Index(name: 'source_id', columns: ['source_id'])]
+#[ORM\UniqueConstraint(name: 'unique', columns: ['doc_id', 'code', 'name', 'value', 'source_id'])]
 class PaperDatasets
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="id", type="integer", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="doc_id", type="integer", nullable=false)
      */
+    #[ORM\Column(name: 'doc_id', type: 'integer', nullable: false)]
     private int $docId;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="code", type="string", length=50, nullable=false)
      */
+    #[ORM\Column(name: 'code', type: 'string', length: 50, nullable: false)]
     private string $code;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="name", type="string", length=200, nullable=false)
      */
+    #[ORM\Column(name: 'name', type: 'string', length: 200, nullable: false)]
     private string $name;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="value", type="string", length=500, nullable=false)
      */
+    #[ORM\Column(name: 'value', type: 'string', length: 500, nullable: false)]
     private string $value;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="link", type="string", length=750, nullable=false)
      */
+    #[ORM\Column(name: 'link', type: 'string', length: 750, nullable: false)]
     private string $link;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="source_id", type="integer", nullable=false)
      */
+    #[ORM\Column(name: 'source_id', type: 'integer', nullable: false)]
     private int $sourceId;
 
-    /**
-     * @var DateTime
-     *
-     * @ORM\Column(name="time", type="datetime", nullable=false, options={"default"="CURRENT_TIMESTAMP"})
-     */
-    private $time = 'CURRENT_TIMESTAMP';
+    #[ORM\Column(name: 'time', type: 'datetime', nullable: false)]
+    private readonly \DateTime $time;
+    public function __construct()
+    {
+        $this->time = new \DateTime('CURRENT_TIMESTAMP');
+    }
 
 
 }

--- a/src/Entity/PaperFiles.php
+++ b/src/Entity/PaperFiles.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use DateTime;
@@ -7,76 +9,67 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperFiles
- *
- * @ORM\Table(name="paper_files", indexes={@ORM\Index(name="doc_id", columns={"doc_id"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'paper_files')]
+#[ORM\Index(name: 'doc_id', columns: ['doc_id'])]
 class PaperFiles
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="id", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'id', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="doc_id", type="integer", nullable=false, options={"unsigned"=true})
      */
+    #[ORM\Column(name: 'doc_id', type: 'integer', nullable: false, options: ['unsigned' => true])]
     private int $docId;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="file_name", type="string", length=500, nullable=false)
      */
+    #[ORM\Column(name: 'file_name', type: 'string', length: 500, nullable: false)]
     private string $fileName;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="checksum", type="string", length=32, nullable=false, options={"fixed"=true})
      */
+    #[ORM\Column(name: 'checksum', type: 'string', length: 32, nullable: false, options: ['fixed' => true])]
     private string $checksum;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="checksum_type", type="string", length=10, nullable=false, options={"fixed"=true})
      */
+    #[ORM\Column(name: 'checksum_type', type: 'string', length: 10, nullable: false, options: ['fixed' => true])]
     private string $checksumType;
 
     /**
      * @var string|null
-     *
-     * @ORM\Column(name="self_link", type="string", length=750, nullable=true)
      */
-    private ?string $selfLink;
+    #[ORM\Column(name: 'self_link', type: 'string', length: 750, nullable: true)]
+    private ?string $selfLink = null;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="file_size", type="bigint", nullable=false, options={"unsigned"=true})
      */
+    #[ORM\Column(name: 'file_size', type: 'bigint', nullable: false, options: ['unsigned' => true])]
     private int $fileSize;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="file_type", type="string", length=20, nullable=false)
      */
+    #[ORM\Column(name: 'file_type', type: 'string', length: 20, nullable: false)]
     private string $fileType;
 
     /**
      * @var DateTime|null
-     *
-     * @ORM\Column(name="time_modified", type="datetime", nullable=true, options={"default"="CURRENT_TIMESTAMP"})
      */
-    private $timeModified = 'CURRENT_TIMESTAMP';
+    #[ORM\Column(name: 'time_modified', type: 'datetime', nullable: true, options: ['default' => 'CURRENT_TIMESTAMP'])]
+    private ?\DateTimeInterface $timeModified = null;
 
 
 }

--- a/src/Entity/PaperLog.php
+++ b/src/Entity/PaperLog.php
@@ -17,46 +17,46 @@ class PaperLog
     public const TABLE = 'PAPER_LOG';
 
 
-    #[ORM\Column(name: 'LOGID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'LOGID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $logid;
+    private int $logid;
 
 
-    #[ORM\Column(name: 'PAPERID', type: 'integer', nullable: false, options: ['unsigned' => true] )]
-    private $paperid;
+    #[ORM\Column(name: 'PAPERID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true] )]
+    private int $paperid;
 
 
-    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+    private int $docid;
 
 
-   #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    private $uid;
+   #[ORM\Column(name: 'UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+    private int $uid;
 
 
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    private $rvid;
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+    private int $rvid;
 
 
-    #[ORM\Column(name: 'ACTION', type: 'string', length: 50, nullable: false)]
-    private $action;
+    #[ORM\Column(name: 'ACTION', type: \Doctrine\DBAL\Types\Types::STRING, length: 50, nullable: false)]
+    private string $action;
 
 
-   #[ORM\Column(name: 'DETAIL', type: 'json', nullable: true)]
-    private ?string $detail;
+   #[ORM\Column(name: 'DETAIL', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
+    private ?string $detail = null;
 
-    #[ORM\Column(name: 'status', type: 'integer',nullable: true, insertable: false, updatable: false, columnDefinition: "SMALLINT GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(DETAIL, '$.status'))) stored",
+    #[ORM\Column(name: 'status', type: \Doctrine\DBAL\Types\Types::INTEGER,nullable: true, insertable: false, updatable: false, columnDefinition: "SMALLINT GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(DETAIL, '$.status'))) stored",
         generated: 'ALWAYS',)]
-    private ?int $status;
+    private ?int $status = null;
 
 
-    #[ORM\Column(name: 'FILE', type: 'string', length: 150, nullable: true)]
-    private $file;
+    #[ORM\Column(name: 'FILE', type: \Doctrine\DBAL\Types\Types::STRING, length: 150, nullable: true)]
+    private ?string $file = null;
 
 
-    #[ORM\Column(name: 'DATE', type: 'datetime', nullable: false)]
-    private $date;
+    #[ORM\Column(name: 'DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
+    private \DateTimeInterface $date;
 
     public function getLogid(): ?int
     {

--- a/src/Entity/PaperRatingGrid.php
+++ b/src/Entity/PaperRatingGrid.php
@@ -6,28 +6,25 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperRatingGrid
- *
- * @ORM\Table(name="PAPER_RATING_GRID")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'PAPER_RATING_GRID')]
 class PaperRatingGrid
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $docid;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="RGID", type="integer", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'RGID', type: 'integer', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $rgid;
 
     public function getDocid(): ?int

--- a/src/Entity/PaperSettings.php
+++ b/src/Entity/PaperSettings.php
@@ -6,41 +6,27 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperSettings
- *
- * @ORM\Table(name="PAPER_SETTINGS")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'PAPER_SETTINGS')]
 class PaperSettings
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="PSID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'PSID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $psid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $docid = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="SETTING", type="string", length=100, nullable=false)
-     */
-    private $setting;
+    #[ORM\Column(name: 'SETTING', type: 'string', length: 100, nullable: false)]
+    private ?string $setting = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="VALUE", type="string", length=250, nullable=true)
-     */
-    private $value;
+    #[ORM\Column(name: 'VALUE', type: 'string', length: 250, nullable: true)]
+    private ?string $value = null;
 
     public function getPsid(): ?int
     {

--- a/src/Entity/PaperStat.php
+++ b/src/Entity/PaperStat.php
@@ -6,110 +6,66 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * PaperStat
- *
- * @ORM\Table(name="PAPER_STAT")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'PAPER_STAT')]
 class PaperStat
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $docid;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="CONSULT", type="string", length=0, nullable=false, options={"default"="notice"})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
-     */
-    private $consult = 'notice';
+    #[ORM\Column(name: 'CONSULT', type: 'string', length: 0, nullable: false, options: ['default' => 'notice'])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
+    private string $consult = 'notice';
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="IP", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'IP', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $ip;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="ROBOT", type="boolean", nullable=false)
-     */
-    private $robot;
+    #[ORM\Column(name: 'ROBOT', type: 'boolean', nullable: false)]
+    private ?bool $robot = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="AGENT", type="string", length=2000, nullable=true)
-     */
-    private $agent;
+    #[ORM\Column(name: 'AGENT', type: 'string', length: 2000, nullable: true)]
+    private ?string $agent = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="DOMAIN", type="string", length=100, nullable=true)
-     */
-    private $domain;
+    #[ORM\Column(name: 'DOMAIN', type: 'string', length: 100, nullable: true)]
+    private ?string $domain = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="CONTINENT", type="string", length=100, nullable=true)
-     */
-    private $continent;
+    #[ORM\Column(name: 'CONTINENT', type: 'string', length: 100, nullable: true)]
+    private ?string $continent = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="COUNTRY", type="string", length=100, nullable=true)
-     */
-    private $country;
+    #[ORM\Column(name: 'COUNTRY', type: 'string', length: 100, nullable: true)]
+    private ?string $country = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="CITY", type="string", length=100, nullable=true)
-     */
-    private $city;
+    #[ORM\Column(name: 'CITY', type: 'string', length: 100, nullable: true)]
+    private ?string $city = null;
 
-    /**
-     * @var float|null
-     *
-     * @ORM\Column(name="LAT", type="float", precision=10, scale=0, nullable=true)
-     */
-    private $lat;
+    #[ORM\Column(name: 'LAT', type: 'float', precision: 10, scale: 0, nullable: true)]
+    private ?float $lat = null;
 
-    /**
-     * @var float|null
-     *
-     * @ORM\Column(name="LON", type="float", precision=10, scale=0, nullable=true)
-     */
-    private $lon;
+    #[ORM\Column(name: 'LON', type: 'float', precision: 10, scale: 0, nullable: true)]
+    private ?float $lon = null;
 
     /**
      * @var \DateTime
-     *
-     * @ORM\Column(name="HIT", type="date", nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'HIT', type: 'date', nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $hit;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="COUNTER", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $counter;
+    #[ORM\Column(name: 'COUNTER', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $counter = null;
 
     public function getDocid(): ?int
     {

--- a/src/Entity/RefreshToken.php
+++ b/src/Entity/RefreshToken.php
@@ -17,40 +17,41 @@ class RefreshToken extends AbstractRefreshTokenAlias
 {
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    #[ORM\Column(name: 'id', type: 'integer')]
-    protected $id;
+    #[ORM\Column(name: 'id', type: \Doctrine\DBAL\Types\Types::INTEGER)]
+    protected $id = null;
 
 
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'refreshToken', type: 'string')]
-    protected $refreshToken;
+    #[ORM\Column(name: 'refreshToken', type: \Doctrine\DBAL\Types\Types::STRING)]
+    protected $refreshToken = null;
 
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'username', type: 'string')]
-    protected $username;
+    #[ORM\Column(name: 'username', type: \Doctrine\DBAL\Types\Types::STRING)]
+    protected $username = null;
 
     /**
      * @var \DateTimeInterface|null
      */
-    #[ORM\Column(name: 'valid', type: 'datetime')]
-    protected $valid;
+    #[ORM\Column(name: 'valid', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE)]
+    protected $valid = null;
 
     #[ORM\Column(name: 'rvid', nullable: true)]
     private ?int $rvId = null;
 
-    #[ORM\Column(type: 'datetime', options: ['default' => 'CURRENT_TIMESTAMP'])]
+    #[ORM\Column(type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, options: ['default' => 'CURRENT_TIMESTAMP'])]
     private ?\DateTimeInterface $date = null;
 
 
 
+    #[\Override]
     public static function createForUserWithTtl(string $refreshToken, User|UserInterface $user, int $ttl): RefreshTokenInterface
     {
         /** @var  $model static */
-        $model = Parent::createForUserWithTtl($refreshToken, $user, $ttl);
+        $model = parent::createForUserWithTtl($refreshToken, $user, $ttl);
         $model->setRvid($user->getCurrentJournalID());
         $model->setDate();
 

--- a/src/Entity/Reminders.php
+++ b/src/Entity/Reminders.php
@@ -6,55 +6,33 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Reminders
- *
- * @ORM\Table(name="REMINDERS")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'REMINDERS')]
 class Reminders
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="ID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=true, options={"unsigned"=true})
-     */
-    private $rvid;
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: true, options: ['unsigned' => true])]
+    private ?int $rvid = null;
 
-    /**
-     * @var bool|null
-     *
-     * @ORM\Column(name="TYPE", type="boolean", nullable=true)
-     */
-    private $type;
+    #[ORM\Column(name: 'TYPE', type: 'boolean', nullable: true)]
+    private ?bool $type = null;
 
-    /**
-     * @var int|null
-     *
-     * @ORM\Column(name="DELAY", type="smallint", nullable=true, options={"unsigned"=true})
-     */
-    private $delay;
+    #[ORM\Column(name: 'DELAY', type: 'smallint', nullable: true, options: ['unsigned' => true])]
+    private ?int $delay = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="RECIPIENT", type="string", length=25, nullable=false, options={"default"="reviewer"})
-     */
-    private $recipient = 'reviewer';
+    #[ORM\Column(name: 'RECIPIENT', type: 'string', length: 25, nullable: false, options: ['default' => 'reviewer'])]
+    private string $recipient = 'reviewer';
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="REPETITION", type="string", length=20, nullable=true)
-     */
-    private $repetition;
+    #[ORM\Column(name: 'REPETITION', type: 'string', length: 20, nullable: true)]
+    private ?string $repetition = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/Review.php
+++ b/src/Entity/Review.php
@@ -365,7 +365,7 @@ class Review
     public const STATUS_ENABLED = 1;
     public const URI_TEMPLATE = '/journals/';
 
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[groups(
@@ -379,7 +379,7 @@ class Review
     private int $rvid;
 
 
-    #[ORM\Column(name: 'CODE', type: 'string', length: 50, nullable: false)]
+    #[ORM\Column(name: 'CODE', type: \Doctrine\DBAL\Types\Types::STRING, length: 50, nullable: false)]
     #[groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
@@ -391,29 +391,29 @@ class Review
     private string $code;
 
 
-    #[ORM\Column(name: 'NAME', type: 'string', length: 2000, nullable: false)]
+    #[ORM\Column(name: 'NAME', type: \Doctrine\DBAL\Types\Types::STRING, length: 2000, nullable: false)]
     #[Groups(['read:Reviews', 'read:Review'])]
     private string $name;
 
-    #[ORM\Column(name: 'SUBTITLE', type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(name: 'SUBTITLE', type: \Doctrine\DBAL\Types\Types::STRING, length: 255, nullable: true)]
     #[Groups(['read:Reviews', 'read:Review'])]
-    #[ApiProperty(readable: true, writable: true, description: 'Le sous-titre du journal')]
+    #[ApiProperty(description: 'Le sous-titre du journal', readable: true, writable: true)]
     private ?string $subtitle = null;
 
-    #[ORM\Column(name: 'STATUS', type: 'smallint', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'STATUS', type: \Doctrine\DBAL\Types\Types::SMALLINT, nullable: false, options: ['unsigned' => true])]
     #[Groups(['read:Reviews'])]
     #[ApiProperty(security: "is_granted('ROLE_EPIADMIN')")] // Property viewable and writable only by users with ROLE_ADMIN
     private int $status;
 
 
-    #[ORM\Column(name: 'CREATION', type: 'datetime', nullable: false)]
+    #[ORM\Column(name: 'CREATION', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
     #[Groups(['read:Reviews'])]
     #[ApiProperty(security: "is_granted('ROLE_EPIADMIN')")]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
     private DateTimeInterface $creation;
 
 
-    #[ORM\Column(name: 'PIWIKID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'PIWIKID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[Groups(['read:Reviews'])]
     #[ApiProperty(security: "is_granted('ROLE_EPIADMIN')")]
     private int $piwikid;
@@ -515,7 +515,7 @@ class Review
     }
 
     /**
-     * @return Collection
+     * @return \Doctrine\Common\Collections\Collection<int, \App\Entity\Paper>
      */
     public function getPapers(): Collection
     {

--- a/src/Entity/ReviewSetting.php
+++ b/src/Entity/ReviewSetting.php
@@ -17,12 +17,12 @@ class ReviewSetting
     public const ALLOW_BROWSE_ACCEPTED_ARTICLE = 'allowBrowseAcceptedDocuments';
     public const DISPLAY_EMPTY_VOLUMES = 'displayEmptyVolumes';
 
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
-    private $rvid;
+    private int $rvid;
 
-    #[ORM\Column(name: 'SETTING', type: 'string', length: 200, nullable: false)]
+    #[ORM\Column(name: 'SETTING', type: \Doctrine\DBAL\Types\Types::STRING, length: 200, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
     #[Groups(
@@ -33,7 +33,7 @@ class ReviewSetting
 
     )]
 
-    private $setting;
+    private string $setting;
     #[Groups(
         [
             'read:Review',
@@ -42,14 +42,14 @@ class ReviewSetting
 
     )]
 
-    #[ORM\Column(name: 'VALUE', type: 'string', length: 65535, nullable: true)]
+    #[ORM\Column(name: 'VALUE', type: \Doctrine\DBAL\Types\Types::STRING, length: 65535, nullable: true)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
 
 
 
 
-    private $value;
+    private ?string $value = null;
 
     #[ORM\ManyToOne(targetEntity: Review::class, inversedBy: 'settings')]
     #[ORM\JoinColumn(name: 'RVID', referencedColumnName: 'RVID', nullable: false)]

--- a/src/Entity/ReviewerAlias.php
+++ b/src/Entity/ReviewerAlias.php
@@ -6,37 +6,33 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * ReviewerAlias
- *
- * @ORM\Table(name="REVIEWER_ALIAS")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'REVIEWER_ALIAS')]
 class ReviewerAlias
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="UID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $uid;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $docid;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="ALIAS", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'ALIAS', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $alias;
 
     public function getUid(): ?int

--- a/src/Entity/ReviewerPool.php
+++ b/src/Entity/ReviewerPool.php
@@ -6,37 +6,33 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * ReviewerPool
- *
- * @ORM\Table(name="REVIEWER_POOL")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'REVIEWER_POOL')]
 class ReviewerPool
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $rvid;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="VID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $vid;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="UID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $uid;
 
     public function getRvid(): ?int

--- a/src/Entity/ReviewerReport.php
+++ b/src/Entity/ReviewerReport.php
@@ -20,7 +20,7 @@ class ReviewerReport
     public const STATUS_WIP = 1;
     public const STATUS_COMPLETED = 2; // rating is completed
 
-    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
@@ -28,34 +28,34 @@ class ReviewerReport
     /**
      * @var int
      */
-    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $uid;
 
     /**
      * @var int|null
      */
-    #[ORM\Column(name: 'ONBEHALF_UID', type: 'integer', nullable: true, options: ['unsigned' => true, 'comment' => 'Mis à jour [!= de NULL] uniquement si l’évaluation est faite à la place de relecteur UID'])]
-    private ?int $onbehalfUid;
+    #[ORM\Column(name: 'ONBEHALF_UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: true, options: ['unsigned' => true, 'comment' => 'Mis à jour [!= de NULL] uniquement si l’évaluation est faite à la place de relecteur UID'])]
+    private ?int $onbehalfUid = null;
 
     /**
      * @var int
      */
-    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'DOCID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $docid;
 
     /**
      * @var int
      */
-    #[ORM\Column(name: 'STATUS', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'STATUS', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $status;
 
 
-    #[ORM\Column(name: 'CREATION_DATE', type: 'datetime', nullable: false)]
+    #[ORM\Column(name: 'CREATION_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
     private DateTimeInterface $creationDate;
 
 
-    #[ORM\Column(name: 'UPDATE_DATE', type: 'datetime', nullable: true)]
-    private ?DateTimeInterface $updateDate;
+    #[ORM\Column(name: 'UPDATE_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true)]
+    private ?DateTimeInterface $updateDate = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/Section.php
+++ b/src/Entity/Section.php
@@ -78,7 +78,7 @@ class Section extends AbstractVolumeSection implements EntityIdentifierInterface
     /**
      * @var int
      */
-    #[ORM\Column(name: 'SID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'SID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[Groups(
@@ -94,7 +94,7 @@ class Section extends AbstractVolumeSection implements EntityIdentifierInterface
     /**
      * @var int
      */
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['section']['item']['read'][0],
@@ -107,10 +107,10 @@ class Section extends AbstractVolumeSection implements EntityIdentifierInterface
     /**
      * @var int
      */
-    #[ORM\Column(name: 'POSITION', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'POSITION', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $position;
 
-    #[ORM\Column(name: 'titles', type: 'json', nullable: true)]
+    #[ORM\Column(name: 'titles', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['section']['item']['read'][0],
@@ -119,9 +119,9 @@ class Section extends AbstractVolumeSection implements EntityIdentifierInterface
         ]
 
     )]
-    private ?array $titles;
+    private ?array $titles = null;
 
-    #[ORM\Column(name: 'descriptions', type: 'json', nullable: true)]
+    #[ORM\Column(name: 'descriptions', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['section']['item']['read'][0],
@@ -129,7 +129,7 @@ class Section extends AbstractVolumeSection implements EntityIdentifierInterface
         ]
 
     )]
-    private ?array $descriptions;
+    private ?array $descriptions = null;
 
     #[ORM\OneToMany(mappedBy: 'section', targetEntity: Paper::class)]
     #[Groups(
@@ -228,6 +228,9 @@ class Section extends AbstractVolumeSection implements EntityIdentifierInterface
         return $this;
     }
 
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \App\Entity\Paper>
+     */
     public function getPapers(): Collection
     {
         return $this->papers;

--- a/src/Entity/SectionSetting.php
+++ b/src/Entity/SectionSetting.php
@@ -18,7 +18,7 @@ class SectionSetting
     /**
      * @var int
      */
-    #[ORM\Column(name: 'SID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'SID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
     private int $sid;
@@ -26,7 +26,7 @@ class SectionSetting
     /**
      * @var string
      */
-    #[ORM\Column(name: 'SETTING', type: 'string', length: 200, nullable: false)]
+    #[ORM\Column(name: 'SETTING', type: \Doctrine\DBAL\Types\Types::STRING, length: 200, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
     #[Groups(
@@ -42,7 +42,7 @@ class SectionSetting
     /**
      * @var string|null
      */
-    #[ORM\Column(name: 'VALUE', type: 'text', length: 65535, nullable: true)]
+    #[ORM\Column(name: 'VALUE', type: \Doctrine\DBAL\Types\Types::TEXT, length: 65535, nullable: true)]
 
     #[Groups(
         [
@@ -52,7 +52,7 @@ class SectionSetting
         ]
 
     )]
-    private ?string $value;
+    private ?string $value = null;
 
     #[ORM\ManyToOne(targetEntity: Section::class, inversedBy: 'settings')]
     #[ORM\JoinColumn(name: 'SID', referencedColumnName: 'SID', nullable: false)]

--- a/src/Entity/StatTemp.php
+++ b/src/Entity/StatTemp.php
@@ -6,55 +6,38 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * StatTemp
- *
- * @ORM\Table(name="STAT_TEMP", indexes={@ORM\Index(name="DOCID", columns={"DOCID"})})
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'STAT_TEMP')]
+#[ORM\Index(name: 'DOCID', columns: ['DOCID'])]
 class StatTemp
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="VISITID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'VISITID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $visitid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="DOCID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $docid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="IP", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $ip;
+    #[ORM\Column(name: 'IP', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $ip = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="HTTP_USER_AGENT", type="string", length=2000, nullable=false)
-     */
-    private $httpUserAgent;
+    #[ORM\Column(name: 'HTTP_USER_AGENT', type: 'string', length: 2000, nullable: false)]
+    private ?string $httpUserAgent = null;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="DHIT", type="datetime", nullable=false, options={"default"="CURRENT_TIMESTAMP"})
-     */
-    private $dhit = 'CURRENT_TIMESTAMP';
+    #[ORM\Column(name: 'DHIT', type: 'datetime', nullable: false)]
+    private \DateTime|\DateTimeInterface $dhit;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="CONSULT", type="string", length=0, nullable=false, options={"default"="notice"})
-     */
-    private $consult = 'notice';
+    #[ORM\Column(name: 'CONSULT', type: 'string', length: 0, nullable: false, options: ['default' => 'notice'])]
+    private string $consult = 'notice';
+    public function __construct()
+    {
+        $this->dhit = new \DateTime('CURRENT_TIMESTAMP');
+    }
 
     public function getVisitid(): ?int
     {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -159,10 +159,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
      * @var array
      */
     #[Groups(['read:User', 'read:Me', 'read:Boards'])]
-    private array $roles;
+    private array $roles = [];
 
     #[ORM\Id]
-    #[ORM\Column(name: "UID", type: "integer", nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: "UID", type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\GeneratedValue]
     #[Groups(
         [
@@ -183,14 +183,14 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
     private ?string $uuid = null;
 
 
-    #[ORM\Column(name: "LANGUEID", type: "string", length: 2, nullable: false, options: ['default' => 'fr'])]
+    #[ORM\Column(name: "LANGUEID", type: \Doctrine\DBAL\Types\Types::STRING, length: 2, nullable: false, options: ['default' => 'fr'])]
     #[Groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
         'read:Me', 'read:Boards'
     ])]
     private string $langueid = 'fr';
-    #[ORM\Column(name: "SCREEN_NAME", type: 'string', length: 250, nullable: false)]
+    #[ORM\Column(name: "SCREEN_NAME", type: \Doctrine\DBAL\Types\Types::STRING, length: 250, nullable: false)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
@@ -205,72 +205,72 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
     private string $screenName;
 
 
-    #[ORM\Column(name: "USERNAME", type: 'string', length: 100, nullable: false)]
+    #[ORM\Column(name: "USERNAME", type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: false)]
     #[ApiProperty(security: "is_granted('ROLE_MEMBER')")]
     #[Groups(['read:Me'])]
     private ?string $username = '';
 
 
-    #[ORM\Column(name: "API_PASSWORD", type: 'string', length: 255)]
-    private ?string $password;
+    #[ORM\Column(name: "API_PASSWORD", type: \Doctrine\DBAL\Types\Types::STRING, length: 255)]
+    private ?string $password = null;
 
 
-    #[ORM\Column(name: "EMAIL", type: 'string', length: 320, nullable: false, options: [])]
+    #[ORM\Column(name: "EMAIL", type: \Doctrine\DBAL\Types\Types::STRING, length: 320, nullable: false, options: [])]
     #[Groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
         'read:Me', 'read:Boards'
     ])]
-    private $email;
+    private string $email;
 
 
-    #[ORM\Column(name: "CIV", type: 'string', length: 255, nullable: true)]
+    #[ORM\Column(name: "CIV", type: \Doctrine\DBAL\Types\Types::STRING, length: 255, nullable: true)]
     #[Groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
         'read:Me', 'read:Boards'
     ])]
-    private $civ;
+    private ?string $civ = null;
 
-    #[ORM\Column(name: "LASTNAME", type: 'string', length: 100, nullable: false)]
+    #[ORM\Column(name: "LASTNAME", type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: false)]
     #[Groups(['read:User', 'read:Me', 'read:Boards'])]
-    private $lastname;
+    private string $lastname;
 
 
-    #[ORM\Column(name: "FIRSTNAME", type: 'string', length: 100, nullable: true)]
+    #[ORM\Column(name: "FIRSTNAME", type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: true)]
     #[Groups(['read:User', 'read:Me', 'read:Boards'])]
-    private $firstname;
+    private ?string $firstname = null;
 
-    #[ORM\Column(name: "MIDDLENAME", type: 'string', length: 100, nullable: true)]
+    #[ORM\Column(name: "MIDDLENAME", type: \Doctrine\DBAL\Types\Types::STRING, length: 100, nullable: true)]
     #[Groups(['read:User', 'read:Me', 'read:Boards'])]
-    private $middlename;
+    private ?string $middlename = null;
 
 
     #[ORM\Column(
-        name: "REGISTRATION_DATE", type: "datetime", nullable: true, options: ['comment' => 'Date de création du compte']
+        name: "REGISTRATION_DATE", type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true, options: ['comment' => 'Date de création du compte']
     )]
     #[ApiProperty(security: "is_granted('ROLE_EPIADMIN')")]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private $registrationDate;
+    private ?\DateTimeInterface $registrationDate = null;
 
 
-    #[ORM\Column(name: "MODIFICATION_DATE", type: 'datetime', nullable: true, options: [
+    #[ORM\Column(name: "MODIFICATION_DATE", type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true, options: [
         'default' => 'CURRENT_TIMESTAMP', 'comment' => 'Date de modification du compte'])
     ]
     #[ApiProperty(security: "is_granted('ROLE_EPIADMIN')")]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private $modificationDate;
+    private ?\DateTimeInterface $modificationDate = null;
 
 
-    #[ORM\Column(name: "ORCID", type: 'string', length: 19, nullable: true)]
+    #[ORM\Column(name: "ORCID", type: \Doctrine\DBAL\Types\Types::STRING, length: 19, nullable: true)]
     #[Groups(['read:User', 'read:Me', 'read:Boards'])]
-    private $orcid = null;
+    private ?string $orcid = null;
 
-    #[ORM\Column(name: 'ADDITIONAL_PROFILE_INFORMATION', type: 'json', nullable: true)]
+    #[ORM\Column(name: 'ADDITIONAL_PROFILE_INFORMATION', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     #[Groups(['read:User', 'read:Me', 'read:Boards'])]
-    private ?array $additionalProfileInformation;
+    private ?array $additionalProfileInformation = null;
 
-    #[ORM\Column(name: "IS_VALID", type: "boolean", nullable: false)]
+    #[ORM\Column(name: "IS_VALID", type: \Doctrine\DBAL\Types\Types::BOOLEAN, nullable: false)]
     #[ApiProperty(security: "is_granted('ROLE_EPIADMIN')")]
     #[Groups(['read:User', 'read:Me'])]
     private bool $isValid = true;
@@ -300,11 +300,10 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
     #[Groups(['read:User', 'read:Me'])]
     private Collection $news;
     #[Groups(['read:Boards'])]
-    private ?array $assignedSections;
+    private ?array $assignedSections = null;
 
-    public function __construct($options = [])
+    public function __construct(array $options = [])
     {
-        $this->roles = [];
         $this->userRoles = new ArrayCollection();
         $this->papers = new ArrayCollection();
         $this->news = new ArrayCollection();
@@ -515,7 +514,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
 
 
     /**
-     * @return Collection
+     * @return \Doctrine\Common\Collections\Collection<int, \App\Entity\UserRoles>
      */
     public function getUserRoles(): Collection
     {
@@ -553,6 +552,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
     }
 
 
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \App\Entity\Paper>
+     */
     public function getPapers(): Collection
     {
         return $this->papers;
@@ -586,7 +588,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
      */
     public function hasRole($roleId, int $rvId): bool
     {
-        return in_array('ROLE_' . strtoupper($roleId), $this->getRoles($rvId), true);
+        return in_array('ROLE_' . strtoupper((string) $roleId), $this->getRoles($rvId), true);
     }
 
     /**
@@ -595,7 +597,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
      */
     public function getRoles(int $rvId = null): array
     {
-        if (empty($this->roles)) {
+        if ($this->roles === []) {
             return $this->rolesProcessing($rvId);
         }
 
@@ -612,7 +614,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
         /* @var UserRoles $userRole */
         foreach ($elements as $userRole) {
 
-            $currentRole = $prefix . strtoupper($userRole->getRoleid());
+            $currentRole = $prefix . strtoupper((string) $userRole->getRoleid());
             $roles[$userRole->getRvid()][] = $currentRole;
         }
         return ($rvId === null || !array_key_exists($rvId, $roles)) ? ['ROLE_USER'] : $roles[$rvId];
@@ -643,7 +645,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
             $wrap = wordwrap($cleanedUuid, 2, DIRECTORY_SEPARATOR, true);
             $picturePath = sprintf('%s%s/%s%s.%s', $pictureDir, $wrap, $prefix, $cleanedUuid, $format);
             if ($this->hasPicture($picturePath)) {
-                if ($encoderType) {
+                if ($encoderType !== '' && $encoderType !== '0') {
                     $imageData = null;
                     $image = file_get_contents($picturePath);
                     if ($image) {
@@ -738,11 +740,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, JWTUser
 
     public function removeNews(News $news): static
     {
-        if ($this->news->removeElement($news)) {
-            // set the owning side to null (unless already changed)
-            if ($news->getCreator() === $this) {
-                $news->setCreator(null);
-            }
+        // set the owning side to null (unless already changed)
+        if ($this->news->removeElement($news) && $news->getCreator() === $this) {
+            $news->setCreator(null);
         }
 
         return $this;

--- a/src/Entity/UserAssignment.php
+++ b/src/Entity/UserAssignment.php
@@ -34,81 +34,78 @@ class UserAssignment
     public const STATUS_CANCELLED = 'cancelled';
     public const STATUS_DECLINED = 'declined';
 
-    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
-    #[ORM\Column(name: 'INVITATION_ID', type: 'integer', nullable:true, options: ['unsigned' => true])]
+    private int $id;
+    #[ORM\Column(name: 'INVITATION_ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable:true, options: ['unsigned' => true])]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
 
-    private $invitationId;
+    private ?int $invitationId = null;
 
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
 
-    private $rvid;
+    private int $rvid;
 
-    #[ORM\Column(name: 'ITEMID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ITEMID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
 
-    private $itemid;
+    private int $itemid;
 
-    #[ORM\Column(name: 'ITEM', type: 'string', length: 50, nullable: false)]
+    #[ORM\Column(name: 'ITEM', type: \Doctrine\DBAL\Types\Types::STRING, length: 50, nullable: false)]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
 
-    private $item;
+    private string $item;
 
-    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    private $uid;
-    #[ORM\Column(name: 'TMP_USER', type: 'boolean', nullable: false)]
+    #[ORM\Column(name: 'UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+    private int $uid;
+    #[ORM\Column(name: 'TMP_USER', type: \Doctrine\DBAL\Types\Types::BOOLEAN, nullable: false)]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
 
-    private $tmpUser;
+    private bool $tmpUser;
 
-    #[ORM\Column(name: 'ROLEID', type: 'string', length: 50, nullable: false)]
-    private $roleid;
+    #[ORM\Column(name: 'ROLEID', type: \Doctrine\DBAL\Types\Types::STRING, length: 50, nullable: false)]
+    private string $roleid;
 
-    #[ORM\Column(name: 'STATUS', type: 'string', length: 20, nullable: false)]
+    #[ORM\Column(name: 'STATUS', type: \Doctrine\DBAL\Types\Types::STRING, length: 20, nullable: false)]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
-    private $status;
+    private string $status;
 
-    #[ORM\Column(name: 'WHEN', type: 'datetime', nullable: false)]
+    #[ORM\Column(name: 'WHEN', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
-    private $when;
+    private \DateTimeInterface $when;
 
     /**
      * @var \DateTime|null
-     *
-     * @ORM\Column(name="DEADLINE", type="datetime", nullable=true)
      */
-    #[ORM\Column(name: 'DEADLINE', type: 'datetime', nullable: true)]
+    #[ORM\Column(name: 'DEADLINE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: true)]
     #[groups([
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['item']['read'][0],
         AppConstants::APP_CONST['normalizationContext']['groups']['papers']['collection']['read'][0]
     ])]
-
-    private $deadline;
+    private ?\DateTimeInterface $deadline = null;
 
     #[ORM\ManyToOne(inversedBy: 'assignments')]
     #[ORM\JoinColumn(name: 'ITEMID', referencedColumnName: 'DOCID', nullable: false)]

--- a/src/Entity/UserInvitation.php
+++ b/src/Entity/UserInvitation.php
@@ -17,34 +17,34 @@ class UserInvitation
 {
     public const TABLE = 'USER_INVITATION';
 
-    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
+    private int $id;
 
     #[ORM\Column(
-        name: 'AID', type: 'integer', nullable: false, options: ['unsigned' => true, 'comment' => 'Assignment ID']
+        name: 'AID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true, 'comment' => 'Assignment ID']
     )]
-    private $aid;
+    private int $aid;
 
-    #[ORM\Column(name: 'STATUS', type: 'string', length: 50, nullable: false, options: ['default' => 'pending'])]
-    private $status = 'pending';
-
-
-    #[ORM\Column(name: 'TOKEN', type: 'string', length: 40, nullable: true)]
-    private $token;
+    #[ORM\Column(name: 'STATUS', type: \Doctrine\DBAL\Types\Types::STRING, length: 50, nullable: false, options: ['default' => 'pending'])]
+    private string $status = 'pending';
 
 
-    #[ORM\Column(name: 'SENDER_UID', type: 'integer', nullable: true, options: ['unsigned' => true])]
-    private $senderUid;
+    #[ORM\Column(name: 'TOKEN', type: \Doctrine\DBAL\Types\Types::STRING, length: 40, nullable: true)]
+    private ?string $token = null;
 
 
-    #[ORM\Column(name: 'SENDING_DATE', type: 'datetime', nullable: false)]
-    private $sendingDate;
+    #[ORM\Column(name: 'SENDER_UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: true, options: ['unsigned' => true])]
+    private ?int $senderUid = null;
 
 
-    #[ORM\Column(name: 'EXPIRATION_DATE', type: 'datetime', nullable: false)]
-    private $expirationDate;
+    #[ORM\Column(name: 'SENDING_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
+    private \DateTimeInterface $sendingDate;
+
+
+    #[ORM\Column(name: 'EXPIRATION_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
+    private \DateTimeInterface $expirationDate;
 
     public function getId(): ?int
     {

--- a/src/Entity/UserInvitationAnswer.php
+++ b/src/Entity/UserInvitationAnswer.php
@@ -11,15 +11,15 @@ class UserInvitationAnswer
 {
 
     #[ORM\Column(
-        name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => 'true', 'comment' => 'Invitation ID']
+        name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => 'true', 'comment' => 'Invitation ID']
     )]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
-    #[ORM\Colmun(name:'ANSWER', type: 'string', length: 10, nullable: false)]
-    private $answer;
-    #[ORM\Column(name: 'ANSWER_DATE', type: 'datetime', nullable: false)]
-    private $answerDate;
+    private int $id;
+    #[ORM\Column(name: 'ANSWER', type: 'string', length: 10, nullable: false)]
+    private ?string $answer = null;
+    #[ORM\Column(name: 'ANSWER_DATE', type: \Doctrine\DBAL\Types\Types::DATETIME_MUTABLE, nullable: false)]
+    private \DateTimeInterface $answerDate;
 
     public function getId(): ?int
     {

--- a/src/Entity/UserInvitationAnswerDetail.php
+++ b/src/Entity/UserInvitationAnswerDetail.php
@@ -10,19 +10,19 @@ class UserInvitationAnswerDetail
 {
 
     #[ORM\Column(
-        name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true, 'comment' => 'Invitation ID']
+        name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true, 'comment' => 'Invitation ID']
     )]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
+    private int $id;
 
-    #[ORM\Column(name:'NAME', type: 'string', length: 30, nullable: false)]
+    #[ORM\Column(name:'NAME', type: \Doctrine\DBAL\Types\Types::STRING, length: 30, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
-    private $name;
+    private string $name;
 
-    #[ORM\Column(name: 'VALUE', type: 'string', length: 500, nullable: true)]
-    private $value;
+    #[ORM\Column(name: 'VALUE', type: \Doctrine\DBAL\Types\Types::STRING, length: 500, nullable: true)]
+    private ?string $value = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/UserMerge.php
+++ b/src/Entity/UserMerge.php
@@ -6,55 +6,37 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * UserMerge
- *
- * @ORM\Table(name="USER_MERGE")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'USER_MERGE')]
 class UserMerge
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="MID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'MID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $mid;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="TOKEN", type="string", length=40, nullable=true)
-     */
-    private $token;
+    #[ORM\Column(name: 'TOKEN', type: 'string', length: 40, nullable: true)]
+    private ?string $token = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="MERGER_UID", type="integer", nullable=false, options={"unsigned"=true,"comment"="CASID du compte à fusionner"})
-     */
-    private $mergerUid;
+    #[ORM\Column(name: 'MERGER_UID', type: 'integer', nullable: false, options: ['unsigned' => true, 'comment' => 'CASID du compte à fusionner'])]
+    private ?int $mergerUid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="KEEPER_UID", type="integer", nullable=false, options={"unsigned"=true,"comment"="CASID du compte à conserver"})
-     */
-    private $keeperUid;
+    #[ORM\Column(name: 'KEEPER_UID', type: 'integer', nullable: false, options: ['unsigned' => true, 'comment' => 'CASID du compte à conserver'])]
+    private ?int $keeperUid = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="DETAIL", type="text", length=65535, nullable=true)
-     */
-    private $detail;
+    #[ORM\Column(name: 'DETAIL', type: 'text', length: 65535, nullable: true)]
+    private ?string $detail = null;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="DATE", type="datetime", nullable=false, options={"default"="CURRENT_TIMESTAMP"})
-     */
-    private $date = 'CURRENT_TIMESTAMP';
+    #[ORM\Column(name: 'DATE', type: 'datetime', nullable: false)]
+    private \DateTime|\DateTimeInterface $date;
+    public function __construct()
+    {
+        $this->date = new \DateTime('CURRENT_TIMESTAMP');
+    }
 
     public function getMid(): ?int
     {

--- a/src/Entity/UserOwnedInterface.php
+++ b/src/Entity/UserOwnedInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Entity;
 
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/src/Entity/UserRoles.php
+++ b/src/Entity/UserRoles.php
@@ -25,36 +25,6 @@ class UserRoles
     public const ROLE_MANAGING_EDITOR = 'managing_editor';
     public const ROLE_HANDLING_EDITOR = 'handling_editor';
 
-    #[ORM\Column(name: 'UID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'NONE')]
-    private $uid;
-
-
-
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'NONE')]
-    #[Groups(
-        [
-            AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
-            AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
-            'read:Me',
-        ])]
-    private $rvid;
-
-
-    #[ORM\Column(name: 'ROLEID', type: 'string', length: 20, nullable: false)]
-    #[ORM\Id]
-    #[ORM\GeneratedValue(strategy: 'NONE')]
-    #[Groups(
-        [
-            AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
-            AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
-            'read:Me',
-        ])]
-    private $roleid;
-
 
    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'userRoles')]
    #[ORM\JoinColumn(name: 'UID', referencedColumnName: 'UID', nullable: true)]
@@ -64,12 +34,35 @@ class UserRoles
             AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
             'read:Me',
         ])]
-    private ?User $user;
+    private ?User $user = null;
 
-    public function __construct($uid, $rvid, $roleid){
-        $this->uid = $uid;
-        $this->rvid = $rvid;
-        $this->roleid = $roleid;
+    public function __construct(
+        #[ORM\Column(name: 'UID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'NONE')]
+        private $uid,
+        #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'NONE')]
+        #[Groups(
+            [
+                AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
+                AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
+                'read:Me',
+            ])]
+        private $rvid,
+        #[ORM\Column(name: 'ROLEID', type: \Doctrine\DBAL\Types\Types::STRING, length: 20, nullable: false)]
+        #[ORM\Id]
+        #[ORM\GeneratedValue(strategy: 'NONE')]
+        #[Groups(
+            [
+                AppConstants::APP_CONST['normalizationContext']['groups']['user']['item']['read'][0],
+                AppConstants::APP_CONST['normalizationContext']['groups']['user']['collection']['read'][0],
+                'read:Me',
+            ])]
+        private $roleid
+    )
+    {
     }
 
     public function getUid(): ?int

--- a/src/Entity/UserTmp.php
+++ b/src/Entity/UserTmp.php
@@ -6,48 +6,30 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * UserTmp
- *
- * @ORM\Table(name="USER_TMP")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'USER_TMP')]
 class UserTmp
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="ID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $id;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="EMAIL", type="string", length=250, nullable=true)
-     */
-    private $email;
+    #[ORM\Column(name: 'EMAIL', type: 'string', length: 250, nullable: true)]
+    private ?string $email = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="FIRSTNAME", type="string", length=100, nullable=true)
-     */
-    private $firstname;
+    #[ORM\Column(name: 'FIRSTNAME', type: 'string', length: 100, nullable: true)]
+    private ?string $firstname = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="LASTNAME", type="string", length=100, nullable=true)
-     */
-    private $lastname;
+    #[ORM\Column(name: 'LASTNAME', type: 'string', length: 100, nullable: true)]
+    private ?string $lastname = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="LANG", type="string", length=3, nullable=true)
-     */
-    private $lang;
+    #[ORM\Column(name: 'LANG', type: 'string', length: 3, nullable: true)]
+    private ?string $lang = null;
 
     public function getId(): ?int
     {

--- a/src/Entity/Volume.php
+++ b/src/Entity/Volume.php
@@ -148,7 +148,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
     public const TABLE = 'VOLUME';
     public const DEFAULT_URI_TEMPLATE = '/volumes{._format}';
 
-    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'VID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     #[Groups(
@@ -171,7 +171,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
     }
 
 
-    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'RVID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -189,10 +189,10 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
         ]
 
     )]
-    #[ORM\Column(name: 'vol_year', type: 'string', length: 9, nullable: true)]
+    #[ORM\Column(name: 'vol_year', type: \Doctrine\DBAL\Types\Types::STRING, length: 9, nullable: true)]
     private ?string $vol_year = null;
 
-    #[ORM\Column(name: 'vol_num', type:'string', length: 6, nullable: true)]
+    #[ORM\Column(name: 'vol_num', type:\Doctrine\DBAL\Types\Types::STRING, length: 6, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -200,7 +200,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
         ]
 
     )]
-    private ?string $vol_num;
+    private ?string $vol_num = null;
 
     #[Groups(
         [
@@ -217,10 +217,10 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
             'example' => 'special_issue'
         ]
     )]
-    #[ORM\Column(type: 'simple_array', nullable: true)]
+    #[ORM\Column(type: \Doctrine\DBAL\Types\Types::SIMPLE_ARRAY, nullable: true)]
     private ?array $vol_type = null;
 
-    #[ORM\Column(name: 'POSITION', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'POSITION', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -230,7 +230,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
     private int $position;
 
 
-    #[ORM\Column(name: 'BIB_REFERENCE', type: 'string', length: 255, nullable: true, options: ['comment' => "Volume's bibliographical reference"])]
+    #[ORM\Column(name: 'BIB_REFERENCE', type: \Doctrine\DBAL\Types\Types::STRING, length: 255, nullable: true, options: ['comment' => "Volume's bibliographical reference"])]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -241,7 +241,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
     private string $bibReference;
 
 
-    #[ORM\Column(name: 'titles', type: 'json', nullable: true)]
+    #[ORM\Column(name: 'titles', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -249,8 +249,8 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
         ]
 
     )]
-    private ?array $titles;
-    #[ORM\Column(name: 'descriptions', type: 'json', nullable: true)]
+    private ?array $titles = null;
+    #[ORM\Column(name: 'descriptions', type: \Doctrine\DBAL\Types\Types::JSON, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -258,7 +258,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
         ]
 
     )]
-    private ?array $descriptions;
+    private ?array $descriptions = null;
 
     #[ORM\OneToMany(mappedBy: 'volume', targetEntity: Paper::class)]
     #[Groups(
@@ -420,7 +420,7 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
 
         $papers = $this->papers->toArray();
 
-        usort($papers, static function(Paper $a, Paper $b) {
+        usort($papers, static function(Paper $a, Paper $b): int {
             $posA = $a->getPaperPosition() ?? PHP_INT_MAX;
             $posB = $b->getPaperPosition() ?? PHP_INT_MAX;
 
@@ -462,6 +462,9 @@ class Volume extends AbstractVolumeSection implements EntityIdentifierInterface
         return $this->settings;
     }
 
+    /**
+     * @return \Doctrine\Common\Collections\Collection<int, \App\Entity\VolumeProceeding>
+     */
     public function getSettingsProceeding(): Collection
     {
         return $this->settings_proceeding;

--- a/src/Entity/VolumeMetadata.php
+++ b/src/Entity/VolumeMetadata.php
@@ -17,23 +17,23 @@ class VolumeMetadata
 
     public const  TABLE = 'VOLUME_METADATA';
 
-    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private int $id;
 
-    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'VID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     private int $vid;
 
 
-    #[ORM\Column(name: 'POSITION', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'POSITION', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
         ]
 
     )]
-    private ?int $position;
+    private ?int $position = null;
 
     #[Groups(
         [
@@ -42,10 +42,10 @@ class VolumeMetadata
         ]
 
     )]
-    #[ORM\Column(name: 'titles', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'titles', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     private array $titles;
 
-    #[ORM\Column(name: 'CONTENT', type: 'json', nullable: false)]
+    #[ORM\Column(name: 'CONTENT', type: \Doctrine\DBAL\Types\Types::JSON, nullable: false)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -53,9 +53,9 @@ class VolumeMetadata
         ]
 
     )]
-    private ?array $content;
+    private ?array $content = null;
 
-    #[ORM\Column(name: 'FILE', type: 'string', length: 250, nullable: true)]
+    #[ORM\Column(name: 'FILE', type: \Doctrine\DBAL\Types\Types::STRING, length: 250, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],
@@ -64,7 +64,7 @@ class VolumeMetadata
         ]
 
     )]
-    private ?string $file;
+    private ?string $file = null;
 
     #[ORM\ManyToOne(targetEntity: Volume::class, inversedBy: 'metadata')]
     #[ORM\JoinColumn(name: 'VID', referencedColumnName: 'VID', nullable: false)]

--- a/src/Entity/VolumePaper.php
+++ b/src/Entity/VolumePaper.php
@@ -18,22 +18,22 @@ class VolumePaper
     /**
      * @var int
      */
-    #[ORM\Column(name: 'ID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'ID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'IDENTITY')]
-    private $id;
+    private int $id;
 
     /**
      * @var int
      */
-    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    private $vid;
+    #[ORM\Column(name: 'VID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+    private int $vid;
 
     /**
      * @var int
      */
-    #[ORM\Column(name: 'DOCID', type: 'integer', nullable: false, options: ['unsigned' => true])]
-    private $docid;
+    #[ORM\Column(name: 'DOCID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
+    private int $docid;
 
     public function getId(): ?int
     {

--- a/src/Entity/VolumePaperPosition.php
+++ b/src/Entity/VolumePaperPosition.php
@@ -9,18 +9,18 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: VolumePaperPositionRepository::class)]
 class VolumePaperPosition
 {
-    #[ORM\Column(name: "VID", type: "integer", nullable: false, options: ["unsigned" => true])]
+    #[ORM\Column(name: "VID", type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ["unsigned" => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: "NONE")]
-    private $vid;
+    private int $vid;
 
-    #[ORM\Column(name: "PAPERID", type: "integer", nullable: false, options: ["unsigned" => true])]
+    #[ORM\Column(name: "PAPERID", type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ["unsigned" => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: "NONE")]
-    private $paperid;
+    private int $paperid;
 
-    #[ORM\Column(name: "POSITION", type: "integer", nullable: false, options: ["unsigned" => true])]
-    private $position;
+    #[ORM\Column(name: "POSITION", type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ["unsigned" => true])]
+    private int $position;
 
     public function getVid(): ?int
     {

--- a/src/Entity/VolumeProceeding.php
+++ b/src/Entity/VolumeProceeding.php
@@ -16,13 +16,13 @@ class VolumeProceeding
     public const TABLE = 'volume_proceeding';
 
 
-    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'VID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
     private int $vid;
 
 
-    #[ORM\Column(name: 'SETTING', type: 'string', length: 200, nullable: false)]
+    #[ORM\Column(name: 'SETTING', type: \Doctrine\DBAL\Types\Types::STRING, length: 200, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
     #[Groups(
@@ -36,7 +36,7 @@ class VolumeProceeding
     private string $setting;
 
 
-    #[ORM\Column(name: 'VALUE', type: 'text', length: 65535, nullable: true)]
+    #[ORM\Column(name: 'VALUE', type: \Doctrine\DBAL\Types\Types::TEXT, length: 65535, nullable: true)]
     #[Groups(
         [
             AppConstants::APP_CONST['normalizationContext']['groups']['volume']['item']['read'][0],

--- a/src/Entity/VolumeSetting.php
+++ b/src/Entity/VolumeSetting.php
@@ -16,13 +16,13 @@ class VolumeSetting
     public const TABLE = 'VOLUME_SETTING';
 
 
-    #[ORM\Column(name: 'VID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Column(name: 'VID', type: \Doctrine\DBAL\Types\Types::INTEGER, nullable: false, options: ['unsigned' => true])]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy:'NONE')]
     private int $vid;
 
 
-    #[ORM\Column(name: 'SETTING', type: 'string', length: 200, nullable: false)]
+    #[ORM\Column(name: 'SETTING', type: \Doctrine\DBAL\Types\Types::STRING, length: 200, nullable: false)]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'NONE')]
 
@@ -37,7 +37,7 @@ class VolumeSetting
     private string $setting;
 
 
-    #[ORM\Column(name: 'VALUE', type: 'text', length: 65535, nullable: true)]
+    #[ORM\Column(name: 'VALUE', type: \Doctrine\DBAL\Types\Types::TEXT, length: 65535, nullable: true)]
 
     #[Groups(
         [

--- a/src/Entity/WebsiteHeader.php
+++ b/src/Entity/WebsiteHeader.php
@@ -6,99 +6,56 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * WebsiteHeader
- *
- * @ORM\Table(name="WEBSITE_HEADER")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'WEBSITE_HEADER')]
 class WebsiteHeader
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="LOGOID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'LOGOID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $logoid;
 
     /**
      * @var int
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $rvid;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TYPE", type="string", length=0, nullable=false)
-     */
-    private $type;
+    #[ORM\Column(name: 'TYPE', type: 'string', length: 0, nullable: false)]
+    private ?string $type = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="IMG", type="string", length=255, nullable=false)
-     */
-    private $img;
+    #[ORM\Column(name: 'IMG', type: 'string', length: 255, nullable: false)]
+    private ?string $img = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="IMG_WIDTH", type="string", length=255, nullable=false)
-     */
-    private $imgWidth;
+    #[ORM\Column(name: 'IMG_WIDTH', type: 'string', length: 255, nullable: false)]
+    private ?string $imgWidth = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="IMG_HEIGHT", type="string", length=255, nullable=false)
-     */
-    private $imgHeight;
+    #[ORM\Column(name: 'IMG_HEIGHT', type: 'string', length: 255, nullable: false)]
+    private ?string $imgHeight = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="IMG_HREF", type="string", length=255, nullable=false)
-     */
-    private $imgHref;
+    #[ORM\Column(name: 'IMG_HREF', type: 'string', length: 255, nullable: false)]
+    private ?string $imgHref = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="IMG_ALT", type="string", length=255, nullable=false)
-     */
-    private $imgAlt;
+    #[ORM\Column(name: 'IMG_ALT', type: 'string', length: 255, nullable: false)]
+    private ?string $imgAlt = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TEXT", type="string", length=1000, nullable=false)
-     */
-    private $text;
+    #[ORM\Column(name: 'TEXT', type: 'string', length: 1000, nullable: false)]
+    private ?string $text = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TEXT_CLASS", type="string", length=255, nullable=false)
-     */
-    private $textClass;
+    #[ORM\Column(name: 'TEXT_CLASS', type: 'string', length: 255, nullable: false)]
+    private ?string $textClass = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TEXT_STYLE", type="string", length=255, nullable=false)
-     */
-    private $textStyle;
+    #[ORM\Column(name: 'TEXT_STYLE', type: 'string', length: 255, nullable: false)]
+    private ?string $textStyle = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ALIGN", type="string", length=10, nullable=false)
-     */
-    private $align;
+    #[ORM\Column(name: 'ALIGN', type: 'string', length: 10, nullable: false)]
+    private ?string $align = null;
 
     public function getLogoid(): ?int
     {

--- a/src/Entity/WebsiteNavigation.php
+++ b/src/Entity/WebsiteNavigation.php
@@ -6,76 +6,42 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * WebsiteNavigation
- *
- * @ORM\Table(name="WEBSITE_NAVIGATION")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'WEBSITE_NAVIGATION')]
 class WebsiteNavigation
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="NAVIGATIONID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
+    #[ORM\Column(name: 'NAVIGATIONID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'IDENTITY')]
     private $navigationid;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="SID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $sid;
+    #[ORM\Column(name: 'SID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $sid = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="PAGEID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $pageid;
+    #[ORM\Column(name: 'PAGEID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $pageid = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="TYPE_PAGE", type="string", length=255, nullable=false)
-     */
-    private $typePage;
+    #[ORM\Column(name: 'TYPE_PAGE', type: 'string', length: 255, nullable: false)]
+    private ?string $typePage = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="CONTROLLER", type="string", length=255, nullable=false)
-     */
-    private $controller;
+    #[ORM\Column(name: 'CONTROLLER', type: 'string', length: 255, nullable: false)]
+    private ?string $controller = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ACTION", type="string", length=255, nullable=false)
-     */
-    private $action;
+    #[ORM\Column(name: 'ACTION', type: 'string', length: 255, nullable: false)]
+    private ?string $action = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="LABEL", type="string", length=500, nullable=false)
-     */
-    private $label;
+    #[ORM\Column(name: 'LABEL', type: 'string', length: 500, nullable: false)]
+    private ?string $label = null;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="PARENT_PAGEID", type="integer", nullable=false, options={"unsigned"=true})
-     */
-    private $parentPageid;
+    #[ORM\Column(name: 'PARENT_PAGEID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    private ?int $parentPageid = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="PARAMS", type="text", length=65535, nullable=false)
-     */
-    private $params;
+    #[ORM\Column(name: 'PARAMS', type: 'text', length: 65535, nullable: false)]
+    private ?string $params = null;
 
     public function getNavigationid(): ?int
     {

--- a/src/Entity/WebsiteSettings.php
+++ b/src/Entity/WebsiteSettings.php
@@ -6,36 +6,29 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * WebsiteSettings
- *
- * @ORM\Table(name="WEBSITE_SETTINGS")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'WEBSITE_SETTINGS')]
 class WebsiteSettings
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="SID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'SID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $sid;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="SETTING", type="string", length=50, nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'SETTING', type: 'string', length: 50, nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $setting;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="VALUE", type="string", length=1000, nullable=false)
-     */
-    private $value;
+    #[ORM\Column(name: 'VALUE', type: 'string', length: 1000, nullable: false)]
+    private ?string $value = null;
 
     public function getSid(): ?int
     {

--- a/src/Entity/WebsiteStyles.php
+++ b/src/Entity/WebsiteStyles.php
@@ -6,36 +6,29 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * WebsiteStyles
- *
- * @ORM\Table(name="WEBSITE_STYLES")
- * @ORM\Entity
  */
+#[ORM\Entity]
+#[ORM\Table(name: 'WEBSITE_STYLES')]
 class WebsiteStyles
 {
     /**
      * @var int
-     *
-     * @ORM\Column(name="RVID", type="integer", nullable=false, options={"unsigned"=true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'RVID', type: 'integer', nullable: false, options: ['unsigned' => true])]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $rvid;
 
     /**
      * @var string
-     *
-     * @ORM\Column(name="SETTING", type="string", length=50, nullable=false)
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="NONE")
      */
+    #[ORM\Column(name: 'SETTING', type: 'string', length: 50, nullable: false)]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'NONE')]
     private $setting;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="VALUE", type="string", length=1000, nullable=false)
-     */
-    private $value;
+    #[ORM\Column(name: 'VALUE', type: 'string', length: 1000, nullable: false)]
+    private ?string $value = null;
 
     public function getRvid(): ?int
     {

--- a/src/EventSubscriber/JWTSubscriber.php
+++ b/src/EventSubscriber/JWTSubscriber.php
@@ -13,14 +13,8 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 class JWTSubscriber implements EventSubscriberInterface
 {
 
-    private RequestStack $requestStack;
-    private ManagerRegistry $doctrine;
-
-
-    public function __construct(RequestStack $requestStack, ManagerRegistry $doctrine)
+    public function __construct(private readonly RequestStack $requestStack, private readonly ManagerRegistry $doctrine)
     {
-        $this->requestStack = $requestStack;
-        $this->doctrine = $doctrine;
     }
 
     /**
@@ -39,7 +33,7 @@ class JWTSubscriber implements EventSubscriberInterface
         $request = $this->requestStack->getCurrentRequest();
 
         $content = $request?->getContent();
-        $postedContent = !empty($content) ? json_decode($content, true, 512, JSON_THROW_ON_ERROR) : [];
+        $postedContent = empty($content) ? [] : json_decode($content, true, 512, JSON_THROW_ON_ERROR);
 
         $rvCode = $postedContent['code'] ?? null;
 

--- a/src/Exception/ResourceNotFoundException.php
+++ b/src/Exception/ResourceNotFoundException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace App\Exception;
 use Exception;
 

--- a/src/Filter/YearFilter.php
+++ b/src/Filter/YearFilter.php
@@ -35,7 +35,7 @@ final class YearFilter extends  AbstractFilter
         }
 
         $description = [];
-        foreach ($this->properties as $property => $strategy) {
+        foreach (array_keys($this->properties) as $property) {
             $description[$property] = [
                 'property' => $property,
                 'type' => 'int',

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -26,11 +26,12 @@ class Kernel extends BaseKernel
             (require $path)($container->withPath($path), $this);
         }
 
+        $appVersion = '1.0.0';
         if (is_file($path = \dirname(__DIR__) . '/version.php') && is_readable($path)) {
             include($path);
         }
 
-        $container->parameters()->set('git_application_version', $appVersion ?? '1.0.0');
+        $container->parameters()->set('git_application_version', $appVersion);
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
@@ -46,6 +47,7 @@ class Kernel extends BaseKernel
     }
 
 
+    #[\Override]
     public function getCacheDir(): string
     {
         return isset($_ENV['CACHE_PATH']) &&
@@ -54,6 +56,7 @@ class Kernel extends BaseKernel
             $_ENV['CACHE_PATH'] . $this->environment : parent::getCacheDir();
     }
 
+    #[\Override]
     public function getLogDir(): string
     {
 

--- a/src/OpenApi/OpenApiFactory.php
+++ b/src/OpenApi/OpenApiFactory.php
@@ -24,7 +24,7 @@ class OpenApiFactory implements OpenApiFactoryInterface
     public const JWT_POST_LOGIN_OPERATION_ID = 'login_check_post';
     public const USER_GET_COLLECTION_PATH = '/api/users';
 
-    private OpenApiFactoryInterface $decorated;
+    private readonly OpenApiFactoryInterface $decorated;
 
     public function __construct(OpenApiFactoryInterface $decorated)
     {

--- a/src/Repository/MetadataSourcesRepository.php
+++ b/src/Repository/MetadataSourcesRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\MetadataSources;

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\Page;

--- a/src/Repository/PaperConflictsRepository.php
+++ b/src/Repository/PaperConflictsRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\PaperConflicts;

--- a/src/Repository/PaperLogRepository.php
+++ b/src/Repository/PaperLogRepository.php
@@ -26,6 +26,7 @@ use Psr\Log\LogLevel;
  * @method PaperLog[]    findAll()
  * @method PaperLog[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  *
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\PaperLog>
  */
 class PaperLogRepository extends ServiceEntityRepository
 {
@@ -37,12 +38,9 @@ class PaperLogRepository extends ServiceEntityRepository
 
     public const AVAILABLE_FILTERS = [AppConstants::WITH_DETAILS, AppConstants::YEAR_PARAM, AppConstants::START_AFTER_DATE];
 
-    private LoggerInterface $logger;
-
-    public function __construct(ManagerRegistry $registry, LoggerInterface $logger)
+    public function __construct(ManagerRegistry $registry, private LoggerInterface $logger)
     {
         parent::__construct($registry, PaperLog::class);
-        $this->logger = $logger;
     }
 
     /**
@@ -178,7 +176,7 @@ class PaperLogRepository extends ServiceEntityRepository
         $papers = 'PAPERS';
         $paperLog = 'PAPER_LOG';
 
-        $year = !$isSubmittedSameYear ? "$papers.SUBMISSION_DATE" : "pl.DATE";
+        $year = $isSubmittedSameYear ? "pl.DATE" : "$papers.SUBMISSION_DATE";
 
 
         $sql = "SELECT $papers.RVID AS rvid, YEAR($year) AS `year`, COUNT(DISTINCT($papers.PAPERID)) AS $as";
@@ -229,9 +227,7 @@ class PaperLogRepository extends ServiceEntityRepository
 
         $delay = array_column($result, self::DELAY);
 
-        $validValues = array_filter($delay, static function ($value) {
-            return is_numeric($value);
-        });
+        $validValues = array_filter($delay, static fn($value) => is_numeric($value));
 
         try {
             $median = $this->getMedian($validValues);
@@ -250,7 +246,7 @@ class PaperLogRepository extends ServiceEntityRepository
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->addSelect("COUNT(DISTINCT(pl.paperid)) AS total");
 
-        if (!empty($years)) {
+        if ($years !== []) {
             $qb->addSelect("YEAR(pl.date) As year");
         }
 
@@ -287,7 +283,7 @@ class PaperLogRepository extends ServiceEntityRepository
     }
 
 
-    public function getAccepted(int $rvId = null, array $years = [], string $startAfterDate = null, $ignoreImportedArticles = true): int
+    public function getAccepted(int $rvId = null, array $years = [], string $startAfterDate = null, bool $ignoreImportedArticles = true): int
     {
 
         $qb = $this->commonQuery($rvId, $years, $startAfterDate, [Paper::STATUS_STRICTLY_ACCEPTED, Paper::STATUS_TMP_VERSION_ACCEPTED], $ignoreImportedArticles);
@@ -295,7 +291,7 @@ class PaperLogRepository extends ServiceEntityRepository
 
     }
 
-    public function getRefused(int $rvId = null, array $years = [], string $startAfterDate = null, $ignoreImportedArticles = true): int
+    public function getRefused(int $rvId = null, array $years = [], string $startAfterDate = null, bool $ignoreImportedArticles = true): int
     {
 
         $qb = $this->commonQuery($rvId, $years, $startAfterDate, Paper::STATUS_REFUSED, $ignoreImportedArticles);
@@ -307,7 +303,7 @@ class PaperLogRepository extends ServiceEntityRepository
     {
         $total = 0;
 
-        if (empty($years)) {
+        if ($years === []) {
             try {
                 return $qb->getQuery()->getSingleScalarResult();
             } catch (NoResultException|NonUniqueResultException  $e) {
@@ -331,14 +327,14 @@ class PaperLogRepository extends ServiceEntityRepository
 
     }
 
-    public function getSubmissions(int $rvId = null, array $years = [], string $startAfterDate = null, $ignoreImportedArticles = true): int
+    public function getSubmissions(int $rvId = null, array $years = [], string $startAfterDate = null, bool $ignoreImportedArticles = true): int
     {
         $qb = $this->commonQuery($rvId, $years, $startAfterDate, Paper::STATUS_SUBMITTED, $ignoreImportedArticles);
         return $this->processResult($qb, $years);
 
     }
 
-    public function getPublished(int $rvId = null, array $years = [], string $startAfterDate = null, $ignoreImportedArticles = true): int
+    public function getPublished(int $rvId = null, array $years = [], string $startAfterDate = null, bool $ignoreImportedArticles = true): int
     {
         $qb = $this->commonQuery($rvId, $years, $startAfterDate, Paper::STATUS_PUBLISHED, $ignoreImportedArticles);
         return $this->processResult($qb, $years);
@@ -346,7 +342,7 @@ class PaperLogRepository extends ServiceEntityRepository
     }
 
 
-    public function getAllAcceptedNotYetPublished(int $rvId = null, array $years = [], string $startAfterDate = null, $ignoreImportedArticles = true): int
+    public function getAllAcceptedNotYetPublished(int $rvId = null, array $years = [], string $startAfterDate = null, bool $ignoreImportedArticles = true): int
     {
 
         $qb = $this->commonQuery($rvId, $years, $startAfterDate, [Paper::STATUS_STRICTLY_ACCEPTED, Paper::STATUS_TMP_VERSION_ACCEPTED], $ignoreImportedArticles);

--- a/src/Repository/PapersRepository.php
+++ b/src/Repository/PapersRepository.php
@@ -26,6 +26,7 @@ use Psr\Log\LoggerInterface;
  * @method Paper[]    findAll()
  * @method Paper[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  *
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\Paper>
  */
 class PapersRepository extends ServiceEntityRepository
 {
@@ -42,12 +43,9 @@ class PapersRepository extends ServiceEntityRepository
         'submitted' => 'submitted'
     ];
 
-    private LoggerInterface $logger;
-
-    public function __construct(ManagerRegistry $registry, LoggerInterface $logger)
+    public function __construct(ManagerRegistry $registry, private LoggerInterface $logger)
     {
         parent::__construct($registry, Paper::class);
-        $this->logger = $logger;
     }
 
     /**
@@ -232,9 +230,7 @@ class PapersRepository extends ServiceEntityRepository
 
         }
 
-        return array_filter($years, static function ($value) {
-            return $value >= Stats::REF_YEAR;
-        });
+        return array_filter($years, static fn($value) => $value >= Stats::REF_YEAR);
 
 
     }
@@ -282,7 +278,7 @@ class PapersRepository extends ServiceEntityRepository
     ): QueryBuilder
     {
 
-        $withoutIdentifier = empty($identifiers);
+        $withoutIdentifier = in_array($identifiers, [0, [], null], true);
 
         $tableId = 'sid'; // section id
 
@@ -344,7 +340,7 @@ class PapersRepository extends ServiceEntityRepository
 
         $resultQuery = $this->getTotalArticlesBySectionOrVolumeQuery($resourceClass, $status, $identifiers, $rvId)->getQuery();
 
-        if (!empty($identifiers || $rvId)) {
+        if ($identifiers || $rvId) {
             try {
                 return [self::TOTAL_ARTICLE => $resultQuery->getSingleScalarResult()];
             } catch (NoResultException|NonUniqueResultException $e) {
@@ -383,7 +379,7 @@ class PapersRepository extends ServiceEntityRepository
         $result = array_values($qb->getQuery()->getArrayResult());
 
         foreach ($result as $type) {
-            $type = strtolower($type['type']);
+            $type = strtolower((string) $type['type']);
             if (!in_array($type, $types, true)) {
                 $types[] = $type;
             }
@@ -416,13 +412,13 @@ class PapersRepository extends ServiceEntityRepository
 
         foreach ($filters as $key => $value) {
 
-            if ($key !== 'rvid' && $key !== 'sid' && $key !== 'vid') {
+            if (!in_array($key, ['rvid', 'sid', 'vid'], true)) {
                 continue;
             }
 
             $value = (int)$value;
 
-            if ($value) {
+            if ($value !== 0) {
                 if ($key === 'rvid') {
                     $qb->andWhere('p.rvid = :rvId');
                     $qb->setParameter('rvId', $value);

--- a/src/Repository/RangeInterface.php
+++ b/src/Repository/RangeInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Resource\Range;

--- a/src/Repository/ReviewRepository.php
+++ b/src/Repository/ReviewRepository.php
@@ -11,8 +11,8 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method Review|null findOneBy(array $criteria, array $orderBy = null)
  * @method Review[]    findAll()
  * @method Review[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\Review>
  */
-
 class ReviewRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)

--- a/src/Repository/ReviewerReportRepository.php
+++ b/src/Repository/ReviewerReportRepository.php
@@ -11,6 +11,9 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\ReviewerReport>
+ */
 class ReviewerReportRepository extends ServiceEntityRepository
 {
     use QueryTrait;

--- a/src/Repository/SectionRepository.php
+++ b/src/Repository/SectionRepository.php
@@ -48,8 +48,8 @@ class SectionRepository extends ServiceEntityRepository
             }
 
             $section = new Section();
-            $titles = $values['titles'] ? json_decode($values['titles'], true, 512, JSON_THROW_ON_ERROR) : null;
-            $descriptions = $values['descriptions'] ? json_decode($values['descriptions'], true, 512, JSON_THROW_ON_ERROR) : null;
+            $titles = $values['titles'] ? json_decode((string) $values['titles'], true, 512, JSON_THROW_ON_ERROR) : null;
+            $descriptions = $values['descriptions'] ? json_decode((string) $values['descriptions'], true, 512, JSON_THROW_ON_ERROR) : null;
             $sections[$values['UID']][] = $section
                 ->setSid($values['SID'])
                 ->setRvid($values['RVID'])

--- a/src/Repository/UserAssignmentRepository.php
+++ b/src/Repository/UserAssignmentRepository.php
@@ -9,6 +9,9 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\UserAssignment>
+ */
 class UserAssignmentRepository extends ServiceEntityRepository
 {
     public function __construct(ManagerRegistry $registry)

--- a/src/Repository/UserInvitationRepository.php
+++ b/src/Repository/UserInvitationRepository.php
@@ -10,6 +10,9 @@ use Doctrine\ORM\Query\Expr\Join;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
+/**
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\UserInvitation>
+ */
 class UserInvitationRepository extends ServiceEntityRepository
 {
     use QueryTrait;

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -17,6 +17,7 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method User[]    findAll()
  * @method User[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  *
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\User>
  */
 class UserRepository extends ServiceEntityRepository
 {

--- a/src/Repository/UserRolesRepository.php
+++ b/src/Repository/UserRolesRepository.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
  * @method UserRoles[]    findAll()
  * @method UserRoles[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
  *
+ * @extends \Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository<\App\Entity\UserRoles>
  */
 class UserRolesRepository extends ServiceEntityRepository
 {
@@ -35,12 +36,9 @@ class UserRolesRepository extends ServiceEntityRepository
         UserRoles::FORMER_MEMBER
     ];
 
-    private LoggerInterface $logger;
-
-    public function __construct(ManagerRegistry $registry, LoggerInterface $logger)
+    public function __construct(ManagerRegistry $registry, private LoggerInterface $logger)
     {
         parent::__construct($registry, UserRoles::class);
-        $this->logger = $logger;
     }
 
 

--- a/src/Repository/VolumePaperPositionRepository.php
+++ b/src/Repository/VolumePaperPositionRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repository;
 
 use App\Entity\VolumePaperPosition;

--- a/src/Repository/VolumeRepository.php
+++ b/src/Repository/VolumeRepository.php
@@ -230,7 +230,7 @@ class VolumeRepository extends AbstractRepository implements RangeInterface
         $vIds = $filters['vid'] ?? null;
 
         $isDisplayEmptyVolume = $filters[ReviewSetting::DISPLAY_EMPTY_VOLUMES] ?? false;
-        $onlyPublished = !isset($context['filters']['isGranted']) || !$context['filters']['isGranted']; // FALSE IF GRANTED SECRETARY
+        $onlyPublished = !isset($filters['isGranted']) || !$filters['isGranted']; // FALSE IF GRANTED SECRETARY
 
         $qb = $this->createQueryBuilder($alias);
 
@@ -318,7 +318,7 @@ class VolumeRepository extends AbstractRepository implements RangeInterface
             return $this->findOneBy($criteria, $orderBy);
         }
 
-        $onlyPublished = !isset($context['filters']['isGranted']) || !$context['filters']['isGranted']; // FALSE IF GRANTED SECRETARY
+        $onlyPublished = !isset($context['isGranted']) || !$context['isGranted']; // FALSE IF GRANTED SECRETARY
         $result = $this->getNoEmptyVolumesIdentifiers(null, $onlyPublished, $vid);
 
         if (in_array($vid, $result, true)) {
@@ -340,7 +340,7 @@ class VolumeRepository extends AbstractRepository implements RangeInterface
     private function processYearRanges(array &$years = []): void
     {
 
-        if (empty($years)) {
+        if ($years === []) {
             return;
         }
 
@@ -354,9 +354,9 @@ class VolumeRepository extends AbstractRepository implements RangeInterface
 
             $separator = '-';
 
-            if (str_contains($currentYear, $separator)) {
+            if (str_contains((string) $currentYear, $separator)) {
 
-                $parts = explode($separator, $currentYear);
+                $parts = explode($separator, (string) $currentYear);
 
                 $start = (int)$parts[0];
                 $end = isset($parts[1]) ? (int)$parts[1] : 0;

--- a/src/Resource/AbstractStatResource.php
+++ b/src/Resource/AbstractStatResource.php
@@ -7,7 +7,7 @@ use App\AppConstants;
 use JsonException;
 use Symfony\Component\Serializer\Attribute\Groups;
 
-abstract class AbstractStatResource
+abstract class AbstractStatResource implements \Stringable
 {
 
     public function __construct(

--- a/src/Resource/Boards.php
+++ b/src/Resource/Boards.php
@@ -6,12 +6,11 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 class Boards
 {
-    #[Groups(['read:Boards'])]
-    private ?array $boards;
-
-    public function __construct(array $boards = null)
+    public function __construct(
+        #[Groups(['read:Boards'])]
+        private ?array $boards = null
+    )
     {
-        $this->boards= $boards;
     }
 
     public function getBoards(): ?array

--- a/src/Resource/Browse.php
+++ b/src/Resource/Browse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Resource;
 
 use ApiPlatform\Metadata\ApiResource;

--- a/src/Resource/Export.php
+++ b/src/Resource/Export.php
@@ -79,7 +79,7 @@ class Export extends AbstractBrowse
 
 
     private int $docId;
-    private ?string $format;
+    private ?string $format = null;
 
     public function getDocId(): int
     {

--- a/src/Resource/Rss.php
+++ b/src/Resource/Rss.php
@@ -40,8 +40,8 @@ class Rss
         $domain = 'episciences.org';
 
         $review = $this->getReview();
-        $code = $review ? $review->getCode() : 'portal';
-        $journalName = $review ? $review->getName() : 'Episciences';
+        $code = $review instanceof \App\Entity\Review ? $review->getCode() : 'portal';
+        $journalName = $review instanceof \App\Entity\Review ? $review->getName() : 'Episciences';
 
         $applicationUrl = sprintf('https://%s.%s', $code, $domain);
         $journalLogo = sprintf('%s/logos/logo-%s-small.svg', $applicationUrl, $code);

--- a/src/Resource/Search.php
+++ b/src/Resource/Search.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Resource;
 
 use ApiPlatform\Metadata\ApiResource;

--- a/src/Resource/SolrDoc.php
+++ b/src/Resource/SolrDoc.php
@@ -196,11 +196,7 @@ class SolrDoc
      */
     public function setLanguageS(string $language_s = self::DEFAULT_LANGUAGE): void
     {
-        if ($language_s !== 'false') {
-            $this->language_s = $language_s;
-        } else {
-            $this->language_s = self::DEFAULT_LANGUAGE;
-        }
+        $this->language_s = $language_s !== 'false' ? $language_s : self::DEFAULT_LANGUAGE;
     }
 
     /**

--- a/src/Resource/Statistic.php
+++ b/src/Resource/Statistic.php
@@ -514,9 +514,9 @@ class Statistic
     #[groups(['read:Statistic'])]
     private string $name;
     #[groups(['read:Statistic'])]
-    private array|float|null $value;
+    private array|float|null $value = null;
     #[groups(['read:Statistic'])]
-    private string|null $unit;
+    private string|null $unit = null;
 
     public function getName(): string
     {

--- a/src/Security/AppCustomJWTAuthenticator.php
+++ b/src/Security/AppCustomJWTAuthenticator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security;
 
 use Lexik\Bundle\JWTAuthenticationBundle\Security\Authenticator\JWTAuthenticator;

--- a/src/Security/Voter/PapersVoter.php
+++ b/src/Security/Voter/PapersVoter.php
@@ -20,11 +20,8 @@ class PapersVoter extends Voter
 
     public const PAPERS_FOLLOW = 'papers_follow';
 
-    private Security $security;
-
-    public function __construct(Security $security)
+    public function __construct(private readonly Security $security)
     {
-        $this->security = $security;
     }
 
     protected function supports(string $attribute, mixed $subject): bool

--- a/src/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Serializer/Normalizer/AbstractNormalizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Serializer\Normalizer;
 
 use App\Service\Solarium\Client;

--- a/src/Serializer/Normalizer/ApiCollectionNormalizer.php
+++ b/src/Serializer/Normalizer/ApiCollectionNormalizer.php
@@ -27,7 +27,7 @@ final class ApiCollectionNormalizer extends AbstractNormalizer implements Normal
 {
     use QueryTrait;
 
-    public const FORMAT = 'jsonld';
+    public const string FORMAT = 'jsonld';
 
     public function setNormalizer(NormalizerInterface $normalizer): void
     {
@@ -102,7 +102,7 @@ final class ApiCollectionNormalizer extends AbstractNormalizer implements Normal
         }
 
         if (
-            !empty($filters) &&
+            $filters !== [] &&
             ($operationClass === Volume::class || $operationClass === Section::class) &&
             $operation->getMethod() === 'GET'
         ) {

--- a/src/Service/Export.php
+++ b/src/Service/Export.php
@@ -55,18 +55,18 @@ class Export extends AbstractSolrService
 
         $solrQuery = sprintf('%s/select/?', $this->parameters->get('app.solr.host'));
 
-        if ($format) {
+        if ($format !== '' && $format !== '0') {
             $solrQuery .= sprintf('fl=%s%s', self::SOLR_CSL_PREFIX, $format);
         }
 
 
-        if ($journal) {
+        if ($journal instanceof \App\Entity\Review) {
             $solrQuery .= '&fq=revue_code_t:' . $journal->getCode();
         }
 
         $solrQuery .= '&indent=true&q.op=OR';
 
-        if ($docId) {
+        if ($docId !== 0) {
             $solrQuery .= sprintf('&q=docid:%s paperid:%s', $docId, $docId);
         }
 
@@ -88,7 +88,7 @@ class Export extends AbstractSolrService
 
         } catch (\JsonException|TransportExceptionInterface|ClientExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface $e) {
             $this->logger->critical($e->getMessage());
-            throw new RuntimeException('Oops! Export cannot be generated: An error occurred');
+            throw new RuntimeException('Oops! Export cannot be generated: An error occurred', $e->getCode(), $e);
 
         }
 

--- a/src/Service/MetadataSources.php
+++ b/src/Service/MetadataSources.php
@@ -8,14 +8,11 @@ use App\Repository\MetadataSourcesRepository;
 class MetadataSources
 {
 
-    private MetadataSourcesRepository $metadataRepository;
     private array $repositories = [];
 
 
-    public function __construct(MetadataSourcesRepository $metadataRepository)
+    public function __construct(private readonly MetadataSourcesRepository $metadataRepository)
     {
-        $this->metadataRepository = $metadataRepository;
-
     }
 
     public function loadRepositories(): void

--- a/src/Service/Solarium/Client.php
+++ b/src/Service/Solarium/Client.php
@@ -16,8 +16,8 @@ use Solarium\QueryType\Select\Result\Result;
 
 class Client extends \Solarium\Client
 {
-    private ?Review $journal;
-    private ?LoggerInterface $logger;
+    private ?Review $journal = null;
+    private ?LoggerInterface $logger = null;
     private array $searchPrams = [];
     private QueryInterface|Query|AbstractQuery $query;
     private array $excludedFilterTags = [];
@@ -81,7 +81,7 @@ class Client extends \Solarium\Client
         $path = null;
 
         $isDefaultPath = false;
-        $defaultPath = sprintf('%s/../config/solr/%s/%s.%s', \dirname(__DIR__), 'default', $key, !$format ? 'json' : $format);
+        $defaultPath = sprintf('%s/../config/solr/%s/%s.%s', \dirname(__DIR__), 'default', $key, $format ?: 'json');
 
         if (is_file($defaultPath) && is_readable($defaultPath)) {
             $isDefaultPath = true;
@@ -89,7 +89,7 @@ class Client extends \Solarium\Client
         }
 
         if ($rvCode = $this->getJournal()?->getCode()) {
-            $path = sprintf('%s/../config/solr/%s/%s.%s', \dirname(__DIR__), $rvCode, $key, !$format ? 'json' : $format);
+            $path = sprintf('%s/../config/solr/%s/%s.%s', \dirname(__DIR__), $rvCode, $key, $format ?: 'json');
             if ($isDefaultPath && (!is_file($path) || !is_readable($path))) {
                 $path = $defaultPath;
             }
@@ -104,7 +104,7 @@ class Client extends \Solarium\Client
                     $toArray = json_decode($config, true, 512, JSON_THROW_ON_ERROR);
                 } catch (\JsonException $e) {
 
-                    if ($this->getLogger()) {
+                    if ($this->getLogger() instanceof \Psr\Log\LoggerInterface) {
                         $this->logger->critical($e->getMessage());
                     }
 
@@ -152,7 +152,7 @@ class Client extends \Solarium\Client
 
         $query->setRows($rows);
 
-        if ($this->journal) {
+        if ($this->journal instanceof \App\Entity\Review) {
             $query
                 ->createFilterQuery(sprintf('df%s', $this->journal->getRvid()))
                 ->setQuery(sprintf('revue_id_i:%s', $this->journal->getRvid()));
@@ -230,14 +230,12 @@ class Client extends \Solarium\Client
                     $param === Search::SEARCH_FILTERS_MAPPING[Search::DOC_TYPE_FILTER]
 
                 ) {
-                    $current = trim($current);
+                    $current = trim((string) $current);
                     $current = trim($current, '"');
                     $current = $helper->escapeTerm($current);
 
                 } elseif (
-                    $param === Search::SEARCH_FILTERS_MAPPING[Search::VOLUME_FILTER] ||
-                    $param === Search::SEARCH_FILTERS_MAPPING[Search::SECTION_FILTER] ||
-                    $param === Search::SEARCH_FILTERS_MAPPING[Search::PUBLICATION_DATE_YEAR_FILTER]
+                    in_array($param, [Search::SEARCH_FILTERS_MAPPING[Search::VOLUME_FILTER], Search::SEARCH_FILTERS_MAPPING[Search::SECTION_FILTER], Search::SEARCH_FILTERS_MAPPING[Search::PUBLICATION_DATE_YEAR_FILTER]], true)
                 ) {
                     $current = (int)$current;
                 }
@@ -253,7 +251,7 @@ class Client extends \Solarium\Client
 
             $compiledValues = trim($compiledValues);
 
-            if (empty($compiledValues)) {
+            if ($compiledValues === '' || $compiledValues === '0') {
                 continue;
             }
 
@@ -287,7 +285,7 @@ class Client extends \Solarium\Client
 
         $facets = $this->getSolrConfig('solr.es.facets');
 
-        if (empty($facets)) {
+        if ($facets === []) {
             return $this;
         }
 
@@ -309,7 +307,7 @@ class Client extends \Solarium\Client
             }
 
             foreach ($excludedTags as $tag) {
-                [$tag, $fieldName] = explode(self::TAG_SEPARATOR, $tag);
+                [$tag, $fieldName] = explode(self::TAG_SEPARATOR, (string) $tag);
 
                 if ($fieldName === $facet['fieldName']) {
                     $current->addExclude($tag);

--- a/src/Service/Solr/AbstractSolrService.php
+++ b/src/Service/Solr/AbstractSolrService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Solr;
 
 use App\Entity\Review;
@@ -44,7 +46,7 @@ abstract class AbstractSolrService
         $queryString = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
 
         foreach ($filters as $filter) {
-            $queryString .= '&fq=' . urlencode($filter);
+            $queryString .= '&fq=' . urlencode((string) $filter);
         }
 
         return $baseUrl . '?' . $queryString;
@@ -52,7 +54,7 @@ abstract class AbstractSolrService
 
     protected function getJournalFilter(): array
     {
-        if ($this->journal === null) {
+        if (!$this->journal instanceof \App\Entity\Review) {
             return [];
         }
 

--- a/src/Service/Solr/SolrAuthorService.php
+++ b/src/Service/Solr/SolrAuthorService.php
@@ -38,7 +38,7 @@ class SolrAuthorService extends AbstractSolrService
             );
         } catch (JsonException|TransportExceptionInterface|ClientExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface $e) {
             $this->logger->critical($e->getMessage());
-            throw new RuntimeException('Oops! An error occurred');
+            throw new RuntimeException('Oops! An error occurred', $e->getCode(), $e);
         }
     }
 

--- a/src/Service/Solr/SolrConstants.php
+++ b/src/Service/Solr/SolrConstants.php
@@ -1,18 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\Solr;
 
 use App\AppConstants;
 
 final class SolrConstants
 {
-    public const SOLR_MAX_RETURNED_FACETS_RESULTS = AppConstants::MAXIMUM_ITEMS_PER_PAGE;
-    public const SOLR_FACET_SEPARATOR = '_FacetSep_';
-    public const SOLR_OTHERS_FACET_SEPARATOR = 'Others_FacetSep_';
-    public const SOLR_OTHERS_PREFIX = 'Others';
-    public const SOLR_ALL_PREFIX = 'All';
-    public const SOLR_INDEX = 'index';
-    public const SOLR_FACET_COUNT = 'count';
-    public const SOLR_FACET_NAME = 'name';
-    public const SOLR_LABEL = 'label';
+    public const int SOLR_MAX_RETURNED_FACETS_RESULTS = AppConstants::MAXIMUM_ITEMS_PER_PAGE;
+    public const string SOLR_FACET_SEPARATOR = '_FacetSep_';
+    public const string SOLR_OTHERS_FACET_SEPARATOR = 'Others_FacetSep_';
+    public const string SOLR_OTHERS_PREFIX = 'Others';
+    public const string SOLR_ALL_PREFIX = 'All';
+    public const string SOLR_INDEX = 'index';
+    public const string SOLR_FACET_COUNT = 'count';
+    public const string SOLR_FACET_NAME = 'name';
+    public const string SOLR_LABEL = 'label';
 }

--- a/src/Service/Solr/SolrFacetService.php
+++ b/src/Service/Solr/SolrFacetService.php
@@ -26,7 +26,7 @@ class SolrFacetService extends AbstractSolrService
             return $this->parseFacetResults($this->transformFacetFieldsToAssoc($data['facet_counts']['facet_fields']['list'] ?? []));
         } catch (JsonException|TransportExceptionInterface|ClientExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface $e) {
             $this->logger->critical($e->getMessage());
-            throw new RuntimeException('Oops! An error occurred');
+            throw new RuntimeException('Oops! An error occurred', $e->getCode(), $e);
         }
     }
 

--- a/src/Service/Solr/SolrFeedService.php
+++ b/src/Service/Solr/SolrFeedService.php
@@ -29,8 +29,8 @@ class SolrFeedService extends AbstractSolrService
         parent::__construct($client, $logger, $parameters, $journal);
     }
 
-    private const FEED_FIELDS = 'paper_title_t,abstract_t,author_fullname_s,revue_code_t,publication_date_tdate,keyword_t,revue_title_s,doi_s,es_doc_url_s,paperid';
-    private const DOI_URL_PREFIX = 'https://doi.org/';
+    private const string FEED_FIELDS = 'paper_title_t,abstract_t,author_fullname_s,revue_code_t,publication_date_tdate,keyword_t,revue_title_s,doi_s,es_doc_url_s,paperid';
+    private const string DOI_URL_PREFIX = 'https://doi.org/';
 
     public function getSolrFeed(string $format = 'rss'): Feed
     {
@@ -46,7 +46,7 @@ class SolrFeedService extends AbstractSolrService
             return $this->processSolrFeed($responseArray, $format);
         } catch (JsonException|TransportExceptionInterface|ClientExceptionInterface|RedirectionExceptionInterface|ServerExceptionInterface $e) {
             $this->logger->critical($e->getMessage());
-            throw new RuntimeException('Oops! Feed cannot be generated: An error occurred');
+            throw new RuntimeException('Oops! Feed cannot be generated: An error occurred', $e->getCode(), $e);
         }
     }
 

--- a/src/Service/Stats.php
+++ b/src/Service/Stats.php
@@ -48,7 +48,7 @@ class Stats
 
     }
 
-    public function getDashboard($context, $filters): DashboardOutput
+    public function getDashboard(array $context, array $filters): DashboardOutput
     {
 
         $years = isset($filters['is']['submissionDate']) ? (array)$filters['is']['submissionDate'] : [];
@@ -125,7 +125,7 @@ class Stats
         $values[$medianSubmissionsDelay->getName()] = $medianSubmissionsDelay->getValue();
         $values[$medianPublicationsDelay->getName()] = $medianPublicationsDelay->getValue();
 
-        if ($years) {
+        if ($years !== []) {
 
             $values = array_merge($values, ['totalAcceptedSubmittedSameYear' => 0, 'totalPublishedSubmittedSameYear' => 0, 'totalRefusedSubmittedSameYear' => 0]);
 
@@ -600,9 +600,7 @@ class Stats
     {
 
         $values = array_column($array, $key);
-        $validValues = array_filter($values, static function ($value) {
-            return is_numeric($value);
-        });
+        $validValues = array_filter($values, static fn($value) => is_numeric($value));
 
         if ($method !== self::MEDIAN_METHOD) {
             return $this->getAvg($validValues);

--- a/src/State/AbstractBrowseStateProvider.php
+++ b/src/State/AbstractBrowseStateProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\State;
 
 use ApiPlatform\State\Pagination\Pagination;

--- a/src/State/AuthenticationStateProvider.php
+++ b/src/State/AuthenticationStateProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\State;
 
 use ApiPlatform\State\Pagination\Pagination;

--- a/src/State/BrowseStateProvider.php
+++ b/src/State/BrowseStateProvider.php
@@ -25,7 +25,7 @@ class BrowseStateProvider extends AbstractBrowseStateProvider implements Provide
     public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
     {
         $request = $this->requestStack->getCurrentRequest();
-        if ($request) {
+        if ($request instanceof \Symfony\Component\HttpFoundation\Request) {
             foreach (['code', 'letter', 'search', 'sort'] as $param) {
                 if (!isset($context['filters'][$param]) && $request->query->has($param)) {
                     $context['filters'][$param] = $request->query->get($param);

--- a/src/State/JournalSettingNgProvider.php
+++ b/src/State/JournalSettingNgProvider.php
@@ -2,21 +2,15 @@
 
 namespace App\State;
 
-use ApiPlatform\Metadata\Exception\RuntimeException;
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
-
 use App\Entity\JournalSettingNg;
 use App\Entity\Review;
-
 use App\Exception\ResourceNotFoundException;
-
-use App\Repository\JournalSettingNgRepository;
-use App\Repository\ReviewRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
-use Symfony\Component\HttpFoundation\Response;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Front settings
@@ -45,15 +39,12 @@ class JournalSettingNgProvider implements ProviderInterface
             return null;
         }
 
-        /** @var ReviewRepository $journalRepo */
         $journalRepo = $this->entityManager->getRepository(Review::class);
         $journal = $journalRepo->getJournalByIdentifier($code);
 
         if (!$journal) {
             throw new ResourceNotFoundException(sprintf('Oops! not found Journal %s', $code));
         }
-
-        /** @var JournalSettingNgRepository $repo */
 
         $repo = $this->entityManager->getRepository(JournalSettingNg::class);
 
@@ -66,10 +57,10 @@ class JournalSettingNgProvider implements ProviderInterface
 
         } catch (NonUniqueResultException $e) {
             $this->logger->critical($e->getMessage());
-            return new \RuntimeException('Oops! An internal error has occurred. Please try again.');
+            throw new \RuntimeException('Oops! An internal error has occurred. Please try again.');
         }
 
-        return new Response($json, Response::HTTP_OK, ['Content-Type' => 'json']);
+        return new Response($json, Response::HTTP_OK, ['Content-Type' => 'application/json']);
 
     }
 }

--- a/src/State/SearchStateProvider.php
+++ b/src/State/SearchStateProvider.php
@@ -39,9 +39,9 @@ class SearchStateProvider extends AbstractStateDataProvider implements ProviderI
 
         $filters = $context['filters'] ?? [];
 
-        $terms = !empty($filters[Search::TERMS_PARAM]) ? trim($filters[Search::TERMS_PARAM]) : null;
+        $terms = empty($filters[Search::TERMS_PARAM]) ? null : trim((string) $filters[Search::TERMS_PARAM]);
 
-        if (empty($terms)) {
+        if (in_array($terms, [null, '', '0'], true)) {
             throw new ResourceNotFoundException('Oops! the required field {terms} is empty or not filled in');
         }
 

--- a/src/State/StatisticStateProvider.php
+++ b/src/State/StatisticStateProvider.php
@@ -93,7 +93,7 @@ class StatisticStateProvider extends AbstractStateDataProvider implements Provid
             $currentFilters['status'] = array_merge($currentFilters['status'] ?? [], (array)$dictionary[$currentStatus]);
         }
 
-        if ($years) {
+        if ($years !== []) {
             $currentFilters[AppConstants::YEAR_PARAM] = $years;
         }
 
@@ -227,7 +227,7 @@ class StatisticStateProvider extends AbstractStateDataProvider implements Provid
             }
 
             $paginator = new ArrayPaginator($response, $firstResult, $maxResults);
-            $this->checkSeekPosition($paginator, $maxResults);
+            $this->checkSeekPosition($paginator);
             return $paginator;
 
         }
@@ -315,7 +315,7 @@ class StatisticStateProvider extends AbstractStateDataProvider implements Provid
 
         foreach ($result as $values) {
             $docId = $values['docid'];
-            $processed[$docId] = !isset($processed[$docId]) ? $values['count'] : ($processed[$docId] + $values['count']);
+            $processed[$docId] = isset($processed[$docId]) ? $processed[$docId] + $values['count'] : ($values['count']);
         }
 
         return array_values($processed);

--- a/src/Traits/QueryTrait.php
+++ b/src/Traits/QueryTrait.php
@@ -27,21 +27,21 @@ trait QueryTrait
             return $qb;
         }
 
-        return $this->andOrExp($qb, sprintf("%s", $yearExp), $values);
+        return $this->andOrExp($qb, $yearExp, $values);
 
     }
 
     final public function processYears(string|array $yFilters = []): array
     {
         if (is_string($yFilters)) {
-            $yFilters = (array($yFilters));
+            $yFilters = ([$yFilters]);
         }
 
         $yFilters = array_unique($yFilters);
 
-        return array_filter($yFilters, static function ($val) { // Supprime à la fois les valeurs nulles et les valeurs vides
-            return !empty($val);
-        });
+        return array_filter($yFilters, 
+            // Supprime à la fois les valeurs nulles et les valeurs vides
+            static fn($val) => !empty($val));
 
     }
 
@@ -66,7 +66,7 @@ trait QueryTrait
         $arrayUnique = array_unique($filters);
 
         foreach ($arrayUnique as $value) {
-            $value = trim($value);
+            $value = trim((string) $value);
             if (in_array($value, $availableTypes, true) && !in_array($value, $availableCurrentTypes, true)) {
                 $availableCurrentTypes[] = $value;
             } elseif (!in_array($value, $unavailableCurrentTypes, true)) {
@@ -75,7 +75,7 @@ trait QueryTrait
         }
 
         // Type SET en MySQL n’est pas nativement supporté par Doctrine ORM
-        return !empty($availableCurrentTypes) ? $availableCurrentTypes : $unavailableCurrentTypes;
+        return $availableCurrentTypes === [] ? $unavailableCurrentTypes : $availableCurrentTypes;
 
     }
 
@@ -123,7 +123,7 @@ trait QueryTrait
     final public function andOrExp(QueryBuilder $qb, string $expression, array $values = [], $isAllowedToReceiveEmptyValues = true): QueryBuilder
     {
 
-        if (empty($values)) {
+        if ($values === []) {
 
             if ($isAllowedToReceiveEmptyValues) {
                 return $qb;
@@ -144,7 +144,7 @@ trait QueryTrait
     final public function andOrLikeExp(QueryBuilder $qb, string $expression, array $values = [], bool $isCaseInsensitive = true, bool $isAllowedToReceiveEmptyValues = true): QueryBuilder
     {
 
-        if (empty($values)) {
+        if ($values === []) {
 
             if ($isAllowedToReceiveEmptyValues) {
                 return $qb;
@@ -158,7 +158,7 @@ trait QueryTrait
         foreach ($values as $val) {
 
             if ($isCaseInsensitive) {
-                $val = strtolower($val);
+                $val = strtolower((string) $val);
             }
 
             $orExp->add($qb->expr()->like($expression, $qb->expr()->literal('%' . $val . '%')));

--- a/src/Traits/ToolsTrait.php
+++ b/src/Traits/ToolsTrait.php
@@ -18,7 +18,7 @@ trait ToolsTrait
     final public function applyFilterBy(array $result, string $extractedKey = null, string $filter = null): array
     {
         if (
-            empty($result) |
+            $result === [] |
             !$extractedKey ||
             isset($result[$extractedKey])
             || !$filter
@@ -100,7 +100,7 @@ trait ToolsTrait
     {
 
         $latestSubString = '';
-        foreach (explode($separator, $string) as $str) {
+        foreach (explode($separator, (string) $string) as $str) {
 
             $latestSubString = $str;
 
@@ -117,7 +117,7 @@ trait ToolsTrait
     /** @throws LengthException */
     public function getMedian(array $array): int|float
     {
-        if (!$array) {
+        if ($array === []) {
             throw new LengthException('Cannot calculate median because Argument #1 ($array) is empty');
         }
 
@@ -151,14 +151,12 @@ trait ToolsTrait
 
     public function arrayCleaner(array $array = []): array
     {
-        return array_filter($array, static function($val) {
-            return !(empty($val));
-        });
+        return array_filter($array, static fn($val) => !(empty($val)));
     }
 
     public function isValidYear( int|string|null $year = null) : bool
     {
-        return preg_match('/^\d{4}$/', $year) === 1 && (int)$year >= self::MIN_YEAR;
+        return preg_match('/^\d{4}$/', (string) $year) === 1 && (int)$year >= self::MIN_YEAR;
     }
 
     /**
@@ -168,7 +166,7 @@ trait ToolsTrait
      */
 
     public function isValideVolumeYear(int|string|null $year = null) : bool {
-        return preg_match('/^(\d{4}|\d{4}-\d{4})$/', $year) === 1;
+        return preg_match('/^(\d{4}|\d{4}-\d{4})$/', (string) $year) === 1;
     }
 
 

--- a/tests/Unit/Controller/BoardsControllerTest.php
+++ b/tests/Unit/Controller/BoardsControllerTest.php
@@ -23,18 +23,19 @@ use Symfony\Component\HttpFoundation\Request;
 class BoardsControllerTest extends TestCase
 {
     private BoardsController $controller;
-    private MockObject|EntityManagerInterface $entityManager;
-    private MockObject|LoggerInterface $logger;
-    private MockObject|ReviewRepository $reviewRepository;
-    private MockObject|UserRolesRepository $userRolesRepository;
-    private MockObject|SectionRepository $sectionRepository;
-    private MockObject|Review $journal;
+    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    private \PHPUnit\Framework\MockObject\MockObject $reviewRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $userRolesRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $sectionRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $journal;
 
     protected function setUp(): void
     {
-        $this->controller = new BoardsController();
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->controller = new BoardsController($this->entityManager, $this->logger);
+        
         $this->reviewRepository = $this->createMock(ReviewRepository::class);
         $this->userRolesRepository = $this->createMock(UserRolesRepository::class);
         $this->sectionRepository = $this->createMock(SectionRepository::class);
@@ -63,7 +64,7 @@ class BoardsControllerTest extends TestCase
 
     public function testReturnsEmptyPaginatorWhenRequestIsNull(): void
     {
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, null);
+        $result = $this->controller->__invoke(null);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
         $this->assertCount(0, $result);
@@ -71,7 +72,7 @@ class BoardsControllerTest extends TestCase
 
     public function testDefaultMaxResultsWithNullRequest(): void
     {
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, null);
+        $result = $this->controller->__invoke(null);
 
         // With no request: pagination=true, page=1, firstResult=0, maxResults=SOLR_MAX
         $this->assertCount(0, $result);
@@ -81,10 +82,10 @@ class BoardsControllerTest extends TestCase
 
     public function testRequestWithoutPaginationParamAndNoCode(): void
     {
-        $request = Request::create('/api/boards', 'GET');
+        $request = Request::create('/api/boards', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         // no 'pagination' query param, no 'code' attribute
 
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
         $this->assertCount(0, $result);
@@ -94,7 +95,7 @@ class BoardsControllerTest extends TestCase
 
     public function testThrowsResourceNotFoundExceptionWhenJournalNotFound(): void
     {
-        $request = Request::create('/api/boards/unknown', 'GET');
+        $request = Request::create('/api/boards/unknown', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'unknown');
 
         $this->entityManager->method('getRepository')
@@ -108,14 +109,14 @@ class BoardsControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('unknown');
 
-        $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $this->controller->__invoke($request);
     }
 
     // ─── Empty board tags ──────────────────────────────────────────────────────
 
     public function testReturnsEmptyPaginatorWhenNoBoardTagsFound(): void
     {
-        $request = Request::create('/api/boards/myjournal', 'GET');
+        $request = Request::create('/api/boards/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->journal->method('getRvid')->willReturn(3);
@@ -128,7 +129,7 @@ class BoardsControllerTest extends TestCase
         $this->userRolesRepository->method('boardsUsersQuery')
             ->willReturn($this->stubQueryBuilder([]));
 
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
         $this->assertCount(0, $result);
@@ -138,7 +139,7 @@ class BoardsControllerTest extends TestCase
 
     public function testReturnsBoardMembersWhenDataExists(): void
     {
-        $request = Request::create('/api/boards/myjournal', 'GET');
+        $request = Request::create('/api/boards/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->journal->method('getRvid')->willReturn(3);
@@ -188,7 +189,7 @@ class BoardsControllerTest extends TestCase
         $this->sectionRepository->method('getAssignedSection')
             ->willReturn([]);
 
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
         $this->assertCount(1, $result);
@@ -198,7 +199,7 @@ class BoardsControllerTest extends TestCase
 
     public function testSkipsUserWithNullUserDataAndLogsInfo(): void
     {
-        $request = Request::create('/api/boards/myjournal', 'GET');
+        $request = Request::create('/api/boards/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->journal->method('getRvid')->willReturn(3);
@@ -226,7 +227,7 @@ class BoardsControllerTest extends TestCase
 
         $this->logger->expects($this->once())->method('info');
 
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertCount(0, $result);
     }
@@ -241,7 +242,7 @@ class BoardsControllerTest extends TestCase
     public function testNullRequestDoesNotCauseUndefinedVariableError(): void
     {
         // Before the fix this would throw "undefined variable $itemsPerPage"
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, null);
+        $result = $this->controller->__invoke(null);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
     }
@@ -250,13 +251,13 @@ class BoardsControllerTest extends TestCase
     {
         // With pagination=true (default), page=2, itemsPerPage=10:
         // firstResult = (2-1) * 10 = 10, maxResults = 10
-        $request = Request::create('/api/boards', 'GET', [
+        $request = Request::create('/api/boards', \Symfony\Component\HttpFoundation\Request::METHOD_GET, [
             'pagination'   => '1',
             'page'         => '2',
             'itemsPerPage' => '10',
         ]);
 
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
     }
@@ -264,9 +265,9 @@ class BoardsControllerTest extends TestCase
     public function testPaginationDisabledWhenParamAbsent(): void
     {
         // No 'pagination' query param → pagination=true, page=1, itemsPerPage=30
-        $request = Request::create('/api/boards', 'GET');
+        $request = Request::create('/api/boards', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
 
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
     }
@@ -275,7 +276,7 @@ class BoardsControllerTest extends TestCase
 
     public function testUserWithOnlyNonBoardRoleIsNotIncluded(): void
     {
-        $request = Request::create('/api/boards/myjournal', 'GET');
+        $request = Request::create('/api/boards/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->journal->method('getRvid')->willReturn(3);
@@ -311,7 +312,7 @@ class BoardsControllerTest extends TestCase
         $this->sectionRepository->method('getAssignedSection')->willReturn([]);
 
         // boardsUsersQuery returns no rows → empty boards
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertCount(0, $result);
     }
@@ -320,7 +321,7 @@ class BoardsControllerTest extends TestCase
 
     public function testSectionExceptionIsHandledGracefully(): void
     {
-        $request = Request::create('/api/boards/myjournal', 'GET');
+        $request = Request::create('/api/boards/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->journal->method('getRvid')->willReturn(3);
@@ -357,7 +358,7 @@ class BoardsControllerTest extends TestCase
         $this->logger->expects($this->once())->method('critical');
 
         // Must not throw — exception is caught internally
-        $result = $this->controller->__invoke($this->entityManager, $this->logger, $request);
+        $result = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(ArrayPaginator::class, $result);
     }

--- a/tests/Unit/Controller/ExportControllerTest.php
+++ b/tests/Unit/Controller/ExportControllerTest.php
@@ -18,17 +18,18 @@ use Symfony\Component\HttpFoundation\Response;
 class ExportControllerTest extends TestCase
 {
     private ExportController $controller;
-    private MockObject|Export $exportService;
-    private MockObject|EntityManagerInterface $entityManager;
-    private MockObject|ReviewRepository $reviewRepository;
-    private MockObject|PapersRepository $papersRepository;
-    private MockObject|Review $journal;
+    private \PHPUnit\Framework\MockObject\MockObject $exportService;
+    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private \PHPUnit\Framework\MockObject\MockObject $reviewRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $papersRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $journal;
 
     protected function setUp(): void
     {
-        $this->controller = new ExportController();
         $this->exportService = $this->createMock(Export::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->controller = new ExportController($this->exportService, $this->entityManager);
+        
         $this->reviewRepository = $this->createMock(ReviewRepository::class);
         $this->papersRepository = $this->createMock(PapersRepository::class);
         $this->journal = $this->createMock(Review::class);
@@ -36,8 +37,8 @@ class ExportControllerTest extends TestCase
 
     private function makeRequest(int $docId = 0, string $format = '', string $code = ''): Request
     {
-        $query = $code ? ['code' => $code] : [];
-        $request = Request::create('/api/export', 'GET', $query);
+        $query = $code !== '' && $code !== '0' ? ['code' => $code] : [];
+        $request = Request::create('/api/export', \Symfony\Component\HttpFoundation\Request::METHOD_GET, $query);
         $request->attributes->set('docid', $docId);
         $request->attributes->set('format', $format);
         return $request;
@@ -50,7 +51,7 @@ class ExportControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('{docid}');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testThrowsWhenFormatIsEmpty(): void
@@ -60,7 +61,7 @@ class ExportControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('{format}');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testThrowsWhenFormatIsInvalid(): void
@@ -70,7 +71,7 @@ class ExportControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('invalid_format');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testThrowsWhenCodeProvidedButJournalNotFound(): void
@@ -88,7 +89,7 @@ class ExportControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('unknown-journal');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testCallsSolrServiceForNonJsonFormat(): void
@@ -105,7 +106,7 @@ class ExportControllerTest extends TestCase
             ->with(42, Export::CSL_FORMAT)
             ->willReturn('{"title":"test"}');
 
-        $response = $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -133,7 +134,7 @@ class ExportControllerTest extends TestCase
             ->with(42, null)
             ->willReturn('{"id":42}');
 
-        $response = $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -163,7 +164,7 @@ class ExportControllerTest extends TestCase
             ->with(42, Export::CSL_FORMAT)
             ->willReturn('<csl>data</csl>');
 
-        $response = $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -176,7 +177,7 @@ class ExportControllerTest extends TestCase
         $this->journal->method('getRvid')->willReturn(7);
 
         $this->entityManager->method('getRepository')->willReturnCallback(
-            fn($class) => match ($class) {
+            fn($class): \App\Repository\ReviewRepository|\PHPUnit\Framework\MockObject\MockObject|\App\Repository\PapersRepository|null => match ($class) {
                 Review::class => $this->reviewRepository,
                 Paper::class  => $this->papersRepository,
                 default       => null,
@@ -191,7 +192,7 @@ class ExportControllerTest extends TestCase
             ->with(42, 7)
             ->willReturn('{"id":42}');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testThrowsWhenExportResultIsNull(): void
@@ -204,7 +205,7 @@ class ExportControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('42');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testThrowsWhenExportResultIsEmptyString(): void
@@ -216,7 +217,7 @@ class ExportControllerTest extends TestCase
 
         $this->expectException(ResourceNotFoundException::class);
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testErrorMessageIncludesJournalCodeWhenSet(): void
@@ -234,12 +235,13 @@ class ExportControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('myjournal');
 
-        $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     /**
      * @dataProvider availableFormatsDataProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('availableFormatsDataProvider')]
     public function testAllAvailableFormatsAreAccepted(string $format): void
     {
         $request = $this->makeRequest(42, $format);
@@ -253,7 +255,7 @@ class ExportControllerTest extends TestCase
             $this->exportService->method('getSolrCSLByFormat')->willReturn('data');
         }
 
-        $response = $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }
@@ -261,7 +263,7 @@ class ExportControllerTest extends TestCase
     public static function availableFormatsDataProvider(): array
     {
         return array_map(
-            static fn(string $fmt) => [$fmt],
+            static fn(string $fmt): array => [$fmt],
             Export::AVAILABLE_FORMATS
         );
     }
@@ -273,7 +275,7 @@ class ExportControllerTest extends TestCase
      */
     public function testCodeFromRouteAttributeIsNotUsedAsJournalFilter(): void
     {
-        $request = Request::create('/api/export', 'GET');
+        $request = Request::create('/api/export', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('docid', 42);
         $request->attributes->set('format', Export::CSL_FORMAT);
         $request->attributes->set('code', 'some-journal'); // only in attributes, not query
@@ -284,7 +286,7 @@ class ExportControllerTest extends TestCase
         $this->exportService->method('setJournal')->with(null)->willReturn($this->exportService);
         $this->exportService->method('getSolrCSLByFormat')->willReturn('data');
 
-        $response = $this->controller->__invoke($request, $this->exportService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
     }

--- a/tests/Unit/Controller/FeedControllerTest.php
+++ b/tests/Unit/Controller/FeedControllerTest.php
@@ -17,17 +17,18 @@ use Symfony\Component\HttpFoundation\Response;
 class FeedControllerTest extends TestCase
 {
     private FeedController $controller;
-    private MockObject|SolrFeedService $feedService;
-    private MockObject|EntityManagerInterface $entityManager;
-    private MockObject|ReviewRepository $reviewRepository;
-    private MockObject|Review $journal;
-    private MockObject|Feed $feed;
+    private \PHPUnit\Framework\MockObject\MockObject $feedService;
+    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private \PHPUnit\Framework\MockObject\MockObject $reviewRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $journal;
+    private \PHPUnit\Framework\MockObject\MockObject $feed;
 
     protected function setUp(): void
     {
-        $this->controller = new FeedController();
         $this->feedService = $this->createMock(SolrFeedService::class);
         $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->controller = new FeedController($this->feedService, $this->entityManager);
+        
         $this->reviewRepository = $this->createMock(ReviewRepository::class);
         $this->journal = $this->createMock(Review::class);
         $this->feed = $this->createMock(Feed::class);
@@ -40,7 +41,7 @@ class FeedControllerTest extends TestCase
 
     public function testInvokeWithRssPath(): void
     {
-        $request = Request::create('/api/feed/rss/testjournal', 'GET');
+        $request = Request::create('/api/feed/rss/testjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'testjournal');
 
         $this->reviewRepository
@@ -65,7 +66,7 @@ class FeedControllerTest extends TestCase
             ->with('rss')
             ->willReturn('<rss>content</rss>');
 
-        $response = $this->controller->__invoke($request, $this->feedService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -75,7 +76,7 @@ class FeedControllerTest extends TestCase
 
     public function testInvokeWithAtomPath(): void
     {
-        $request = Request::create('/api/feed/atom/testjournal', 'GET');
+        $request = Request::create('/api/feed/atom/testjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'testjournal');
 
         $this->reviewRepository
@@ -100,7 +101,7 @@ class FeedControllerTest extends TestCase
             ->with('atom')
             ->willReturn('<feed>content</feed>');
 
-        $response = $this->controller->__invoke($request, $this->feedService, $this->entityManager);
+        $response = $this->controller->__invoke($request);
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -110,7 +111,7 @@ class FeedControllerTest extends TestCase
 
     public function testInvokeThrowsExceptionWhenJournalNotFound(): void
     {
-        $request = Request::create('/api/feed/rss/nonexistent', 'GET');
+        $request = Request::create('/api/feed/rss/nonexistent', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'nonexistent');
 
         $this->reviewRepository
@@ -121,12 +122,12 @@ class FeedControllerTest extends TestCase
         $this->expectException(ResourceNotFoundException::class);
         $this->expectExceptionMessage('Oops! Feed cannot be generated: not found Journal nonexistent');
 
-        $this->controller->__invoke($request, $this->feedService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testFormatDetectionWithAtomInPath(): void
     {
-        $request = Request::create('/api/feed/atom/myjournal', 'GET');
+        $request = Request::create('/api/feed/atom/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->reviewRepository
@@ -145,12 +146,12 @@ class FeedControllerTest extends TestCase
 
         $this->feed->method('export')->willReturn('');
 
-        $this->controller->__invoke($request, $this->feedService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 
     public function testFormatDetectionDefaultsToRss(): void
     {
-        $request = Request::create('/api/feed/rss/myjournal', 'GET');
+        $request = Request::create('/api/feed/rss/myjournal', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
         $request->attributes->set('code', 'myjournal');
 
         $this->reviewRepository
@@ -169,6 +170,6 @@ class FeedControllerTest extends TestCase
 
         $this->feed->method('export')->willReturn('');
 
-        $this->controller->__invoke($request, $this->feedService, $this->entityManager);
+        $this->controller->__invoke($request);
     }
 }

--- a/tests/Unit/Controller/MeControllerTest.php
+++ b/tests/Unit/Controller/MeControllerTest.php
@@ -13,9 +13,9 @@ use Symfony\Bundle\SecurityBundle\Security;
 class MeControllerTest extends TestCase
 {
     private MeController $controller;
-    private MockObject|Security $security;
-    private MockObject|ManagerRegistry $doctrine;
-    private MockObject|UserRepository $userRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $security;
+    private \PHPUnit\Framework\MockObject\MockObject $doctrine;
+    private \PHPUnit\Framework\MockObject\MockObject $userRepository;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Controller/PapersControllerTest.php
+++ b/tests/Unit/Controller/PapersControllerTest.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Request;
 class PapersControllerTest extends TestCase
 {
     private PapersController $controller;
-    private MockObject|EntityManagerInterface $entityManager;
-    private MockObject|UserRepository $userRepository;
-    private MockObject|PapersRepository $paperRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
+    private \PHPUnit\Framework\MockObject\MockObject $userRepository;
+    private \PHPUnit\Framework\MockObject\MockObject $paperRepository;
 
     protected function setUp(): void
     {
@@ -71,7 +71,7 @@ class PapersControllerTest extends TestCase
 
     public function testThrowsMissingParameterExceptionWhenDocumentIdAbsent(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET');
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET);
 
         $this->expectException(MissingRequestParameterException::class);
         $this->expectExceptionMessage('Required "documentId" parameter in "Request query" is not present.');
@@ -83,7 +83,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsFalseWhenUserIdIsZeroInAttributes(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         // uid not set in route attributes → (int)null = 0 → skip user lookup
 
         $this->entityManager->expects($this->never())->method('getRepository');
@@ -100,7 +100,7 @@ class PapersControllerTest extends TestCase
      */
     public function testUidFromQueryStringIsNotUsed(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42, 'uid' => 99]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42, 'uid' => 99]);
         // No attributes->set('uid') → secure path: uid is 0 → no DB lookup
 
         $this->entityManager->expects($this->never())->method('getRepository');
@@ -114,7 +114,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsFalseWhenUserNotFound(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $this->entityManager->method('getRepository')->willReturnMap([
@@ -130,7 +130,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsFalseWhenPaperNotFound(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $user = $this->createMock(User::class);
@@ -152,9 +152,10 @@ class PapersControllerTest extends TestCase
     /**
      * @dataProvider rolesGrantingAccessDataProvider
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('rolesGrantingAccessDataProvider')]
     public function testReturnsTrueWhenUserHasAllowedRole(string $role): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $rvId = 5;
@@ -163,7 +164,7 @@ class PapersControllerTest extends TestCase
         $paper = $this->buildPaperMock($rvId, ownerUid: 0);
 
         $user->method('hasRole')->willReturnCallback(
-            static fn($r, $rv) => $r === $role && $rv === $rvId
+            static fn($r, $rv): bool => $r === $role && $rv === $rvId
         );
 
         $this->entityManager->method('getRepository')->willReturnMap([
@@ -192,7 +193,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsTrueWhenUserIsTheOwnerOfPaper(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $user = $this->createMock(User::class);
@@ -216,7 +217,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsTrueWhenUserIsCoAuthorOfPaper(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $user = $this->createMock(User::class);
@@ -239,7 +240,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsTrueWhenUserIsEditorOfPaper(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $user = $this->createMock(User::class);
@@ -262,7 +263,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsTrueWhenUserIsCopyEditorOfPaper(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $user = $this->createMock(User::class);
@@ -285,7 +286,7 @@ class PapersControllerTest extends TestCase
 
     public function testReturnsFalseWhenUserHasNoRoleAndNotInAnyEditorList(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 42]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 42]);
         $request->attributes->set('uid', 99);
 
         $user = $this->createMock(User::class);
@@ -311,7 +312,7 @@ class PapersControllerTest extends TestCase
 
     public function testDocumentIdIsReadFromQueryStringAndCastToInt(): void
     {
-        $request = Request::create('/api/papers/citations', 'GET', ['documentId' => 7]);
+        $request = Request::create('/api/papers/citations', \Symfony\Component\HttpFoundation\Request::METHOD_GET, ['documentId' => 7]);
         $request->attributes->set('uid', 10);
 
         $user = $this->createMock(User::class);

--- a/tests/Unit/DataProvider/AbstractDataProviderTest.php
+++ b/tests/Unit/DataProvider/AbstractDataProviderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Tests\Unit\DataProvider;
+
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operation;
+use App\AppConstants;
+use App\DataProvider\AbstractDataProvider;
+use App\Entity\Review;
+use App\Exception\ResourceNotFoundException;
+use App\Resource\DashboardOutput;
+use App\Resource\SubmissionOutput;
+use App\Resource\UsersStatsOutput;
+use App\Resource\SubmissionAcceptanceDelayOutput;
+use App\Resource\SubmissionPublicationDelayOutput;
+use App\Service\Stats;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TestableDataProvider extends AbstractDataProvider
+{
+    public function supports(Operation $operation = null): bool
+    {
+        return true;
+    }
+
+    public function exposeGetCollection(Operation $operation, array $context = []): mixed
+    {
+        return $this->getCollection($operation, $context);
+    }
+}
+
+class AbstractDataProviderTest extends TestCase
+{
+    private TestableDataProvider $dataProvider;
+    private MockObject $entityManager;
+    private MockObject $statsService;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->statsService = $this->createMock(Stats::class);
+        $this->dataProvider = new TestableDataProvider($this->entityManager, $this->statsService);
+    }
+
+    public function testThrowsResourceNotFoundExceptionWhenJournalNotFound(): void
+    {
+        $this->statsService->method('getJournal')->willReturn(null);
+
+        $operation = new Get();
+        $context = [
+            'uri_variables' => ['code' => 'unknown']
+        ];
+
+        $this->expectException(ResourceNotFoundException::class);
+        $this->expectExceptionMessage('Oops! not found Journal unknown');
+
+        $this->dataProvider->exposeGetCollection($operation, $context);
+    }
+
+    public function testDashboardItemCallsGetDashboard(): void
+    {
+        $journal = $this->createMock(Review::class);
+        $journal->method('getRvid')->willReturn(42);
+
+        $this->statsService->method('getJournal')->willReturn($journal);
+
+        $dashboardOutput = new DashboardOutput();
+        $this->statsService->expects($this->once())
+            ->method('getDashboard')
+            ->willReturn($dashboardOutput);
+
+        $operation = new Get(name: AppConstants::APP_CONST['custom_operations']['items']['review'][0]);
+        
+        $context = ['uri_variables' => ['code' => 'myjournal'], 'filters' => []];
+
+        $result = $this->dataProvider->exposeGetCollection($operation, $context);
+
+        $this->assertSame($dashboardOutput, $result);
+    }
+
+    public function testNbSubmissionsItemCallsGetSubmissionsStat(): void
+    {
+        $journal = $this->createMock(Review::class);
+        $journal->method('getRvid')->willReturn(42);
+
+        $this->statsService->method('getJournal')->willReturn($journal);
+
+        $submissionOutput = new SubmissionOutput();
+        $this->statsService->expects($this->once())
+            ->method('getSubmissionsStat')
+            ->willReturn($submissionOutput);
+
+        $operation = new Get(name: AppConstants::APP_CONST['custom_operations']['items']['review'][1]);
+        $context = ['uri_variables' => ['code' => 'myjournal'], 'filters' => []];
+
+        $result = $this->dataProvider->exposeGetCollection($operation, $context);
+
+        $this->assertSame($submissionOutput, $result);
+    }
+
+    public function testAddFiltersTransformsContextFiltersCorrectly(): void
+    {
+        $journal = $this->createMock(Review::class);
+        $journal->method('getRvid')->willReturn(42);
+
+        $this->statsService->method('getJournal')->willReturn($journal);
+
+        // We use STATS_NB_SUBMISSIONS_ITEM because it enables additional filters
+        $operation = new Get(name: AppConstants::STATS_NB_SUBMISSIONS_ITEM);
+        $context = [
+            'uri_variables' => ['code' => 'myjournal'],
+            'filters' => [
+                AppConstants::WITH_DETAILS => 'true',
+                AppConstants::START_AFTER_DATE => '2023-01-01',
+                AppConstants::YEAR_PARAM => '2022'
+            ]
+        ];
+
+        $this->statsService->expects($this->once())
+            ->method('getSubmissionsStat')
+            ->with($this->callback(function (array $filters) {
+                // Validates that addFilters mapped parameters correctly
+                return isset($filters['is']['rvid']) && $filters['is']['rvid'] === '42'
+                    && isset($filters['is'][AppConstants::WITH_DETAILS]) && $filters['is'][AppConstants::WITH_DETAILS] === true
+                    && isset($filters['is'][AppConstants::START_AFTER_DATE]) && $filters['is'][AppConstants::START_AFTER_DATE] === '2023-01-01'
+                    && isset($filters['is']['submissionDate']) && $filters['is']['submissionDate'] === '2022';
+            }))
+            ->willReturn(new SubmissionOutput());
+
+        $this->dataProvider->exposeGetCollection($operation, $context);
+    }
+}

--- a/tests/Unit/Entity/JournalSettingNgTest.php
+++ b/tests/Unit/Entity/JournalSettingNgTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\JournalSettingNg;
+use PHPUnit\Framework\TestCase;
+
+class JournalSettingNgTest extends TestCase
+{
+    private JournalSettingNg $entity;
+
+    protected function setUp(): void
+    {
+        $this->entity = new JournalSettingNg();
+    }
+
+    public function testTableConstant(): void
+    {
+        $this->assertSame('JOURNAL_SETTING', JournalSettingNg::TABLE);
+    }
+
+    public function testSetAndGetId(): void
+    {
+        $result = $this->entity->setId(42);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertSame(42, $this->entity->getId());
+    }
+
+    public function testSetAndGetRvid(): void
+    {
+        $result = $this->entity->setRvid(7);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertSame(7, $this->entity->getRvid());
+    }
+
+    public function testSetRvidOverwritesPreviousValue(): void
+    {
+        $this->entity->setRvid(10);
+        $this->entity->setRvid(20);
+
+        $this->assertSame(20, $this->entity->getRvid());
+    }
+
+    public function testSetAndGetSettings(): void
+    {
+        $settings = ['menu' => ['authorsRender' => true], 'theme' => ['primaryColor' => '#49737e']];
+
+        $result = $this->entity->setSettings($settings);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertSame($settings, $this->entity->getSettings());
+    }
+
+    public function testSetAndGetCreatedAt(): void
+    {
+        $date = new \DateTime('2024-01-15 10:00:00');
+
+        $result = $this->entity->setCreatedAt($date);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertSame($date, $this->entity->getCreatedAt());
+    }
+
+    public function testCreatedAtIsNullable(): void
+    {
+        $this->entity->setCreatedAt(new \DateTime());
+        $result = $this->entity->setCreatedAt(null);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertNull($this->entity->getCreatedAt());
+    }
+
+    public function testSetAndGetUpdatedAt(): void
+    {
+        $date = new \DateTimeImmutable('2024-06-01 08:30:00');
+
+        $result = $this->entity->setUpdatedAt($date);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertSame($date, $this->entity->getUpdatedAt());
+    }
+
+    public function testUpdatedAtIsNullable(): void
+    {
+        $this->entity->setUpdatedAt(new \DateTime());
+        $result = $this->entity->setUpdatedAt(null);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertNull($this->entity->getUpdatedAt());
+    }
+
+    public function testFluentChaining(): void
+    {
+        $settings = ['key' => 'value'];
+        $date = new \DateTime();
+
+        $result = $this->entity
+            ->setId(1)
+            ->setRvid(5)
+            ->setSettings($settings)
+            ->setCreatedAt($date)
+            ->setUpdatedAt($date);
+
+        $this->assertSame($this->entity, $result);
+        $this->assertSame(1, $this->entity->getId());
+        $this->assertSame(5, $this->entity->getRvid());
+        $this->assertSame($settings, $this->entity->getSettings());
+        $this->assertSame($date, $this->entity->getCreatedAt());
+        $this->assertSame($date, $this->entity->getUpdatedAt());
+    }
+}

--- a/tests/Unit/EventSubscriber/JWTSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/JWTSubscriberTest.php
@@ -77,9 +77,7 @@ class JWTSubscriberTest extends TestCase
 
         $event->expects($this->once())
             ->method('setData')
-            ->with($this->callback(static function (array $d) {
-                return $d['uid'] === 42 && $d['rvId'] === 7 && isset($d['roles']);
-            }));
+            ->with($this->callback(static fn(array $d) => $d['uid'] === 42 && $d['rvId'] === 7 && isset($d['roles'])));
 
         $this->subscriber->onLexikJwtAuthenticationOnJwtCreated($event);
     }
@@ -88,7 +86,7 @@ class JWTSubscriberTest extends TestCase
 
     public function testEmptyRequestBodyDoesNotThrowJsonException(): void
     {
-        $request = Request::create('/api/login', 'POST', [], [], [], [], '');
+        $request = Request::create('/api/login', \Symfony\Component\HttpFoundation\Request::METHOD_POST, [], [], [], [], '');
         $this->requestStack->method('getCurrentRequest')->willReturn($request);
 
         $user  = $this->makeUser(1, null);
@@ -105,7 +103,7 @@ class JWTSubscriberTest extends TestCase
     public function testRequestWithoutCodeKeyUsesDefaultRvId(): void
     {
         $body    = json_encode(['username' => 'user@example.com', 'password' => 'secret'], JSON_THROW_ON_ERROR);
-        $request = Request::create('/api/login', 'POST', [], [], [], [], $body);
+        $request = Request::create('/api/login', \Symfony\Component\HttpFoundation\Request::METHOD_POST, [], [], [], [], $body);
         $this->requestStack->method('getCurrentRequest')->willReturn($request);
 
         $user  = $this->makeUser(5, 3);
@@ -113,7 +111,7 @@ class JWTSubscriberTest extends TestCase
 
         $event->expects($this->once())
             ->method('setData')
-            ->with($this->callback(static fn(array $d) => $d['rvId'] === 3 && $d['uid'] === 5));
+            ->with($this->callback(static fn(array $d): bool => $d['rvId'] === 3 && $d['uid'] === 5));
 
         $this->subscriber->onLexikJwtAuthenticationOnJwtCreated($event);
     }
@@ -123,7 +121,7 @@ class JWTSubscriberTest extends TestCase
     public function testValidJournalCodeSetsRvId(): void
     {
         $body    = json_encode(['code' => 'myjournal'], JSON_THROW_ON_ERROR);
-        $request = Request::create('/api/login', 'POST', [], [], [], [], $body);
+        $request = Request::create('/api/login', \Symfony\Component\HttpFoundation\Request::METHOD_POST, [], [], [], [], $body);
         $this->requestStack->method('getCurrentRequest')->willReturn($request);
 
         $review = $this->createMock(Review::class);
@@ -138,7 +136,7 @@ class JWTSubscriberTest extends TestCase
         $event = $this->makeEvent($user);
         $event->expects($this->once())
             ->method('setData')
-            ->with($this->callback(static fn(array $d) => $d['rvId'] === 99));
+            ->with($this->callback(static fn(array $d): bool => $d['rvId'] === 99));
 
         $this->subscriber->onLexikJwtAuthenticationOnJwtCreated($event);
     }
@@ -148,7 +146,7 @@ class JWTSubscriberTest extends TestCase
     public function testUnknownJournalCodeThrowsBadRequest(): void
     {
         $body    = json_encode(['code' => 'unknown'], JSON_THROW_ON_ERROR);
-        $request = Request::create('/api/login', 'POST', [], [], [], [], $body);
+        $request = Request::create('/api/login', \Symfony\Component\HttpFoundation\Request::METHOD_POST, [], [], [], [], $body);
         $this->requestStack->method('getCurrentRequest')->willReturn($request);
 
         $this->reviewRepo->method('getJournalByIdentifier')->with('unknown')->willReturn(null);
@@ -167,7 +165,7 @@ class JWTSubscriberTest extends TestCase
     public function testInactiveJournalThrowsBadRequest(): void
     {
         $body    = json_encode(['code' => 'inactive'], JSON_THROW_ON_ERROR);
-        $request = Request::create('/api/login', 'POST', [], [], [], [], $body);
+        $request = Request::create('/api/login', \Symfony\Component\HttpFoundation\Request::METHOD_POST, [], [], [], [], $body);
         $this->requestStack->method('getCurrentRequest')->willReturn($request);
 
         $review = $this->createMock(Review::class);

--- a/tests/Unit/EventSubscriber/VolumeSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/VolumeSubscriberTest.php
@@ -70,7 +70,7 @@ class VolumeSubscriberTest extends TestCase
         $volume->method('getVid')->willReturn(1);
         $volume->expects($this->once())
             ->method('setPapers')
-            ->with($this->callback(static fn(ArrayCollection $c) => count($c) === 2))
+            ->with($this->callback(static fn(ArrayCollection $c): bool => count($c) === 2))
             ->willReturnSelf();
         $volume->method('getPapers')->willReturn(new ArrayCollection());
 

--- a/tests/Unit/Exception/MissingRequestParameterExceptionTest.php
+++ b/tests/Unit/Exception/MissingRequestParameterExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Exception;
 
 use App\Exception\MissingRequestParameterException;

--- a/tests/Unit/Filter/YearFilterTest.php
+++ b/tests/Unit/Filter/YearFilterTest.php
@@ -14,8 +14,8 @@ use PHPUnit\Framework\TestCase;
 class YearFilterTest extends TestCase
 {
     private YearFilter $filter;
-    private ManagerRegistry $managerRegistry;
-    private EntityManagerInterface $entityManager;
+    private \PHPUnit\Framework\MockObject\MockObject $managerRegistry;
+    private \PHPUnit\Framework\MockObject\MockObject $entityManager;
 
     protected function setUp(): void
     {
@@ -33,7 +33,7 @@ class YearFilterTest extends TestCase
 
     public function testGetDescriptionWithProperties(): void
     {
-        $resourceClass = 'App\Entity\Paper';
+        $resourceClass = \App\Entity\Paper::class;
         
         $description = $this->filter->getDescription($resourceClass);
 
@@ -61,7 +61,7 @@ class YearFilterTest extends TestCase
         ];
         
         $filter = new YearFilter($this->managerRegistry, null, $properties);
-        $description = $filter->getDescription('App\Entity\Paper');
+        $description = $filter->getDescription(\App\Entity\Paper::class);
 
         $this->assertCount(3, $description);
         $this->assertArrayHasKey('submissionDate', $description);
@@ -79,7 +79,7 @@ class YearFilterTest extends TestCase
     public function testGetDescriptionWithNoProperties(): void
     {
         $filter = new YearFilter($this->managerRegistry, null, []);
-        $description = $filter->getDescription('App\Entity\Paper');
+        $description = $filter->getDescription(\App\Entity\Paper::class);
 
         $this->assertEmpty($description);
     }
@@ -87,7 +87,7 @@ class YearFilterTest extends TestCase
     public function testGetDescriptionWithNullProperties(): void
     {
         $filter = new YearFilter($this->managerRegistry, null, null);
-        $description = $filter->getDescription('App\Entity\Paper');
+        $description = $filter->getDescription(\App\Entity\Paper::class);
 
         $this->assertEmpty($description);
     }

--- a/tests/Unit/Repository/JournalSettingNgRepositoryTest.php
+++ b/tests/Unit/Repository/JournalSettingNgRepositoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Repository;
+
+use App\Entity\JournalSettingNg;
+use App\Repository\JournalSettingNgRepository;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class JournalSettingNgRepositoryTest extends TestCase
+{
+    private JournalSettingNgRepository $repository;
+    private MockObject $entityManager;
+    private MockObject $queryBuilder;
+    private MockObject $query;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->query = $this->createMock(AbstractQuery::class);
+
+        $classMetadata = $this->createMock(ClassMetadata::class);
+        $classMetadata->name = JournalSettingNg::class;
+
+        $this->entityManager
+            ->method('getClassMetadata')
+            ->with(JournalSettingNg::class)
+            ->willReturn($classMetadata);
+
+        $this->entityManager
+            ->method('createQueryBuilder')
+            ->willReturn($this->queryBuilder);
+
+        // EntityRepository::createQueryBuilder('fs') calls select('fs') then from(...) internally
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('andWhere')->willReturnSelf();
+        $this->queryBuilder->method('setParameter')->willReturnSelf();
+        $this->queryBuilder->method('getQuery')->willReturn($this->query);
+        $this->queryBuilder->method('getRootAliases')->willReturn(['fs']);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->entityManager);
+
+        $this->repository = new JournalSettingNgRepository($registry);
+    }
+
+    public function testGetFrontSettingsFiltersOnRvid(): void
+    {
+        $rvId = 42;
+
+        $this->queryBuilder
+            ->expects($this->once())
+            ->method('andWhere')
+            ->with('fs.rvid= :rvId')
+            ->willReturnSelf();
+
+        $this->queryBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with('rvId', $rvId)
+            ->willReturnSelf();
+
+        $this->query
+            ->method('getOneOrNullResult')
+            ->with(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+            ->willReturn(['menu' => ['authorsRender' => true]]);
+
+        $result = $this->repository->getFrontSettings($rvId);
+
+        $this->assertSame(['menu' => ['authorsRender' => true]], $result);
+    }
+
+    public function testGetFrontSettingsReturnsNullWhenNoRecord(): void
+    {
+        $this->query
+            ->method('getOneOrNullResult')
+            ->with(AbstractQuery::HYDRATE_SCALAR_COLUMN)
+            ->willReturn(null);
+
+        $result = $this->repository->getFrontSettings(999);
+
+        $this->assertNull($result);
+    }
+
+    public function testGetFrontSettingsPropagatesNonUniqueResultException(): void
+    {
+        $this->query
+            ->method('getOneOrNullResult')
+            ->willThrowException(new NonUniqueResultException());
+
+        $this->expectException(NonUniqueResultException::class);
+
+        $this->repository->getFrontSettings(1);
+    }
+}

--- a/tests/Unit/SampleTest.php
+++ b/tests/Unit/SampleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Service/ExportServiceTest.php
+++ b/tests/Unit/Service/ExportServiceTest.php
@@ -10,8 +10,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ExportServiceTest extends TestCase
 {
-    private Export $exportService;
-    private ParameterBagInterface $parameterBag;
+    private \PHPUnit\Framework\MockObject\MockObject $exportService;
+    private \PHPUnit\Framework\MockObject\MockObject $parameterBag;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Service/MetadataSourcesTest.php
+++ b/tests/Unit/Service/MetadataSourcesTest.php
@@ -5,13 +5,12 @@ namespace App\Tests\Unit\Service;
 use App\Entity\MetadataSources as MetadataSourcesEntity;
 use App\Repository\MetadataSourcesRepository;
 use App\Service\MetadataSources;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class MetadataSourcesTest extends TestCase
 {
-    private MockObject|MetadataSourcesRepository $repository;
-    private MetadataSources $service;
+    private $repository;
+    private $service;
 
     protected function setUp(): void
     {
@@ -19,118 +18,37 @@ class MetadataSourcesTest extends TestCase
         $this->service = new MetadataSources($this->repository);
     }
 
-    // --- getRepositories() ---
-
-    public function testGetRepositoriesLazyLoadsFromDatabase(): void
+    public function testGetLabelReturnsCorrectName(): void
     {
-        $repo1 = $this->createMock(MetadataSourcesEntity::class);
-        $repo2 = $this->createMock(MetadataSourcesEntity::class);
+        $entity = $this->createMock(MetadataSourcesEntity::class);
+        $entity->method('getName')->willReturn('HAL');
 
-        $this->repository
-            ->expects($this->once()) // must query DB only once (lazy load)
-            ->method('findAll')
-            ->willReturn([$repo1, $repo2]);
+        $this->repository->method('findAll')->willReturn([
+            1 => $entity
+        ]);
 
-        $result = $this->service->getRepositories();
-
-        $this->assertCount(2, $result);
+        $this->assertEquals('HAL', $this->service->getLabel(1));
     }
 
-    public function testGetRepositoriesCachesResultOnSecondCall(): void
-    {
-        $repo = $this->createMock(MetadataSourcesEntity::class);
-
-        $this->repository
-            ->expects($this->once()) // DB called only once despite two calls
-            ->method('findAll')
-            ->willReturn([$repo]);
-
-        $this->service->getRepositories();
-        $this->service->getRepositories(); // second call must hit the cache
-    }
-
-    public function testGetRepositoriesReturnsEmptyArrayWhenNoneFound(): void
+    public function testGetLabelThrowsExceptionWhenNotFound(): void
     {
         $this->repository->method('findAll')->willReturn([]);
 
-        $result = $this->service->getRepositories();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->service->getLabel(99);
+    }
 
+    public function testRepositoryToArrayReturnsArray(): void
+    {
+        $entity = $this->createMock(MetadataSourcesEntity::class);
+        $entity->method('toArray')->willReturn(['id' => 1, 'name' => 'HAL']);
+
+        $this->repository->method('findAll')->willReturn([
+            1 => $entity
+        ]);
+
+        $result = $this->service->repositoryToArray(1);
         $this->assertIsArray($result);
-        $this->assertEmpty($result);
-    }
-
-    // --- loadRepositories() ---
-
-    public function testLoadRepositoriesRefreshesCache(): void
-    {
-        $repo1 = $this->createMock(MetadataSourcesEntity::class);
-        $repo2 = $this->createMock(MetadataSourcesEntity::class);
-
-        $this->repository
-            ->expects($this->exactly(2))
-            ->method('findAll')
-            ->willReturn([$repo1, $repo2]);
-
-        $this->service->loadRepositories();
-        $this->service->loadRepositories(); // explicit reload must hit DB again
-    }
-
-    // --- getLabel() ---
-
-    public function testGetLabelReturnsNameForKnownRepoId(): void
-    {
-        $repoEntity = $this->createMock(MetadataSourcesEntity::class);
-        $repoEntity->method('getName')->willReturn('HAL');
-
-        $this->repository->method('findAll')->willReturn([1 => $repoEntity]);
-
-        $label = $this->service->getLabel(1);
-
-        $this->assertSame('HAL', $label);
-    }
-
-    public function testGetLabelThrowsForUnknownRepoId(): void
-    {
-        $this->repository->method('findAll')->willReturn([]);
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('42');
-
-        $this->service->getLabel(42);
-    }
-
-    public function testGetLabelThrowsWithDescriptiveMessageContainingId(): void
-    {
-        $this->repository->method('findAll')->willReturn([]);
-
-        try {
-            $this->service->getLabel(99);
-            $this->fail('Expected InvalidArgumentException');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertStringContainsString('99', $e->getMessage());
-        }
-    }
-
-    // --- repositoryToArray() ---
-
-    public function testRepositoryToArrayDelegatesToEntity(): void
-    {
-        $repoEntity = $this->createMock(MetadataSourcesEntity::class);
-        $repoEntity->method('toArray')->willReturn(['id' => 3, 'name' => 'arXiv']);
-
-        $this->repository->method('findAll')->willReturn([3 => $repoEntity]);
-
-        $result = $this->service->repositoryToArray(3);
-
-        $this->assertSame(['id' => 3, 'name' => 'arXiv'], $result);
-    }
-
-    public function testRepositoryToArrayThrowsForUnknownId(): void
-    {
-        $this->repository->method('findAll')->willReturn([]);
-
-        $this->expectException(\InvalidArgumentException::class);
-
-        $this->service->repositoryToArray(7);
+        $this->assertEquals('HAL', $result['name']);
     }
 }

--- a/tests/Unit/Service/Solr/SolrAuthorServiceTest.php
+++ b/tests/Unit/Service/Solr/SolrAuthorServiceTest.php
@@ -15,10 +15,10 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SolrAuthorServiceTest extends TestCase
 {
-    private MockObject|HttpClientInterface $httpClient;
-    private MockObject|LoggerInterface $logger;
-    private MockObject|ParameterBagInterface $parameterBag;
-    private MockObject|SolrFacetService $facetService;
+    private \PHPUnit\Framework\MockObject\MockObject $httpClient;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    private \PHPUnit\Framework\MockObject\MockObject $parameterBag;
+    private \PHPUnit\Framework\MockObject\MockObject $facetService;
     private SolrAuthorService $authorService;
 
     protected function setUp(): void
@@ -118,9 +118,7 @@ class SolrAuthorServiceTest extends TestCase
         $this->httpClient
             ->expects($this->once())
             ->method('request')
-            ->with('GET', $this->callback(function ($url) {
-                return str_contains($url, 'author_fullname_t%3A');
-            }))
+            ->with('GET', $this->callback(fn($url) => str_contains((string) $url, 'author_fullname_t%3A')))
             ->willReturn($response);
 
         $this->authorService->getSolrAuthorsByFullName('O\'Brien, Patrick');

--- a/tests/Unit/Service/Solr/SolrFacetServiceTest.php
+++ b/tests/Unit/Service/Solr/SolrFacetServiceTest.php
@@ -14,9 +14,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SolrFacetServiceTest extends TestCase
 {
-    private MockObject|HttpClientInterface $httpClient;
-    private MockObject|LoggerInterface $logger;
-    private MockObject|ParameterBagInterface $parameterBag;
+    private \PHPUnit\Framework\MockObject\MockObject $httpClient;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    private \PHPUnit\Framework\MockObject\MockObject $parameterBag;
     private SolrFacetService $facetService;
 
     protected function setUp(): void

--- a/tests/Unit/Service/Solr/SolrFeedServiceTest.php
+++ b/tests/Unit/Service/Solr/SolrFeedServiceTest.php
@@ -13,9 +13,9 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class SolrFeedServiceTest extends TestCase
 {
-    private MockObject|HttpClientInterface $httpClient;
-    private MockObject|LoggerInterface $logger;
-    private MockObject|ParameterBagInterface $parameterBag;
+    private \PHPUnit\Framework\MockObject\MockObject $httpClient;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
+    private \PHPUnit\Framework\MockObject\MockObject $parameterBag;
     private SolrFeedService $feedService;
 
     protected function setUp(): void

--- a/tests/Unit/Service/StatsTest.php
+++ b/tests/Unit/Service/StatsTest.php
@@ -28,15 +28,15 @@ use Psr\Log\LoggerInterface;
 
 class StatsTest extends TestCase
 {
-    private MockObject|EntityManagerInterface $em;
-    private MockObject|MetadataSources $metadataSources;
-    private MockObject|LoggerInterface $logger;
+    private \PHPUnit\Framework\MockObject\MockObject $em;
+    private \PHPUnit\Framework\MockObject\MockObject $metadataSources;
+    private \PHPUnit\Framework\MockObject\MockObject $logger;
     private Stats $stats;
 
-    private MockObject|PaperLogRepository $paperLogRepo;
-    private MockObject|PapersRepository $papersRepo;
-    private MockObject|UserRepository $userRepo;
-    private MockObject|ReviewRepository $reviewRepo;
+    private \PHPUnit\Framework\MockObject\MockObject $paperLogRepo;
+    private \PHPUnit\Framework\MockObject\MockObject $papersRepo;
+    private \PHPUnit\Framework\MockObject\MockObject $userRepo;
+    private \PHPUnit\Framework\MockObject\MockObject $reviewRepo;
 
     protected function setUp(): void
     {
@@ -49,7 +49,7 @@ class StatsTest extends TestCase
         $this->userRepo     = $this->createMock(UserRepository::class);
         $this->reviewRepo   = $this->createMock(ReviewRepository::class);
 
-        $this->em->method('getRepository')->willReturnCallback(fn (string $class) => match ($class) {
+        $this->em->method('getRepository')->willReturnCallback(fn (string $class): \PHPUnit\Framework\MockObject\MockObject|\App\Repository\PaperLogRepository|\App\Repository\PapersRepository|\App\Repository\UserRepository|\App\Repository\ReviewRepository|null => match ($class) {
             PaperLog::class => $this->paperLogRepo,
             Paper::class    => $this->papersRepo,
             User::class     => $this->userRepo,
@@ -526,5 +526,39 @@ class StatsTest extends TestCase
 
         $this->assertNotNull($result->getDetails());
         $this->assertNotEmpty($result->getDetails());
+    }
+
+    public function testGetSubmissionByYearStatsPopulatesDetails(): void
+    {
+        $filters = ['is' => ['rvid' => 8]];
+        $rvId = 8;
+        $details = [];
+
+        $this->papersRepo->method('getSubmissionYearRange')->willReturn([2023]);
+        $this->papersRepo->method('getAvailableRepositories')->willReturn([1]);
+        $this->metadataSources->method('getLabel')->with(1)->willReturn('HAL');
+
+        // Mocking various repository calls inside the loop
+        $this->papersRepo->method('submissionsQuery')->willReturn($this->makeScalarQb(10));
+        $this->papersRepo->method('getSubmissionsWithoutImported')->willReturn(8);
+        
+        $this->paperLogRepo->method('getAccepted')->willReturn(5);
+        $this->paperLogRepo->method('getRefused')->willReturn(2);
+        $this->paperLogRepo->method('getPublished')->willReturn(4);
+        $this->paperLogRepo->method('getAllAcceptedNotYetPublished')->willReturn(1);
+        $this->paperLogRepo->method('getAcceptanceRate')->willReturn(71.4);
+        $this->paperLogRepo->method('totalNbPapersByStatusStatement')->willReturn(null); // Simple case for getNbPapersByStatus
+
+        $this->stats->getSubmissionByYearStats($filters, $rvId, $details);
+
+        $this->assertArrayHasKey(Stats::SUBMISSIONS_BY_YEAR, $details);
+        $this->assertArrayHasKey(2023, $details[Stats::SUBMISSIONS_BY_YEAR]);
+        $this->assertEquals(10, $details[Stats::SUBMISSIONS_BY_YEAR][2023]['submissions']);
+        $this->assertEquals(4, $details[Stats::SUBMISSIONS_BY_YEAR][2023]['published']);
+        
+        $this->assertArrayHasKey('submissionsByRepo', $details);
+        $this->assertArrayHasKey(2023, $details['submissionsByRepo']);
+        $this->assertArrayHasKey('HAL', $details['submissionsByRepo'][2023]);
+        $this->assertEquals(10, $details['submissionsByRepo'][2023]['HAL']['submissions']);
     }
 }

--- a/tests/Unit/State/JournalSettingNgProviderTest.php
+++ b/tests/Unit/State/JournalSettingNgProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\State;
+
+use ApiPlatform\Metadata\Get;
+use App\Entity\JournalSettingNg;
+use App\Entity\Review;
+use App\Exception\ResourceNotFoundException;
+use App\Repository\JournalSettingNgRepository;
+use App\Repository\ReviewRepository;
+use App\State\JournalSettingNgProvider;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\NonUniqueResultException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+class JournalSettingNgProviderTest extends TestCase
+{
+    private JournalSettingNgProvider $provider;
+    private MockObject $entityManager;
+    private MockObject $logger;
+    private MockObject $reviewRepo;
+    private MockObject $settingRepo;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->reviewRepo = $this->createMock(ReviewRepository::class);
+        $this->settingRepo = $this->createMock(JournalSettingNgRepository::class);
+
+        $this->entityManager
+            ->method('getRepository')
+            ->willReturnMap([
+                [Review::class, $this->reviewRepo],
+                [JournalSettingNg::class, $this->settingRepo],
+            ]);
+
+        $this->provider = new JournalSettingNgProvider($this->entityManager, $this->logger);
+    }
+
+    public function testProvideReturnsNullWhenCodeIsAbsent(): void
+    {
+        $result = $this->provider->provide(new Get(), [], []);
+
+        $this->assertNull($result);
+    }
+
+    public function testProvideReturnsNullWhenCodeIsEmptyString(): void
+    {
+        $result = $this->provider->provide(new Get(), [], ['filters' => ['code' => '']]);
+
+        $this->assertNull($result);
+    }
+
+    public function testProvideThrowsResourceNotFoundWhenJournalNotFound(): void
+    {
+        $this->reviewRepo
+            ->method('getJournalByIdentifier')
+            ->with('unknown')
+            ->willReturn(null);
+
+        $this->expectException(ResourceNotFoundException::class);
+        $this->expectExceptionMessage('Oops! not found Journal unknown');
+
+        $this->provider->provide(new Get(), [], ['filters' => ['code' => 'unknown']]);
+    }
+
+    public function testProvideThrowsResourceNotFoundWhenSettingsNotFound(): void
+    {
+        $journal = $this->createMock(Review::class);
+        $journal->method('getRvid')->willReturn(5);
+
+        $this->reviewRepo->method('getJournalByIdentifier')->willReturn($journal);
+        $this->settingRepo->method('getFrontSettings')->with(5)->willReturn(null);
+
+        $this->expectException(ResourceNotFoundException::class);
+        $this->expectExceptionMessage('No configuration found for');
+
+        $this->provider->provide(new Get(), [], ['filters' => ['code' => 'epijinfo']]);
+    }
+
+    public function testProvideReturnsResponseWithJsonSettings(): void
+    {
+        $journal = $this->createMock(Review::class);
+        $journal->method('getRvid')->willReturn(12);
+
+        $rawJson = '{"menu":{"authorsRender":true},"theme":{"primaryColor":"#49737e"}}';
+
+        $this->reviewRepo->method('getJournalByIdentifier')->with('myjournal')->willReturn($journal);
+        $this->settingRepo->method('getFrontSettings')->with(12)->willReturn($rawJson);
+
+        $result = $this->provider->provide(new Get(), [], ['filters' => ['code' => 'myjournal']]);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertSame(Response::HTTP_OK, $result->getStatusCode());
+        $this->assertSame('application/json', $result->headers->get('Content-Type'));
+        $this->assertSame($rawJson, $result->getContent());
+    }
+
+    public function testProvideLogsAndThrowsOnNonUniqueResultException(): void
+    {
+        $journal = $this->createMock(Review::class);
+        $journal->method('getRvid')->willReturn(3);
+
+        $this->reviewRepo->method('getJournalByIdentifier')->willReturn($journal);
+
+        $exception = new NonUniqueResultException('multiple rows');
+        $this->settingRepo->method('getFrontSettings')->willThrowException($exception);
+
+        $this->logger
+            ->expects($this->once())
+            ->method('critical')
+            ->with('multiple rows');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Oops! An internal error has occurred. Please try again.');
+
+        $this->provider->provide(new Get(), [], ['filters' => ['code' => 'epijinfo']]);
+    }
+}

--- a/tests/Unit/Traits/ToolsTraitTest.php
+++ b/tests/Unit/Traits/ToolsTraitTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Traits;
 
 use App\Traits\ToolsTrait;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
## Summary

- **Build & infra**: bump PHP to 8.3 in composer and Docker, update Rector/PHPUnit config, add Makefile helpers
- **PHP 8.3 migration**: apply Rector transformations across all `src/` (typed properties, return types, Doctrine `Types::` constants, modern syntax); fix PHPStan level-1 errors; fix pre-existing bugs (undefined variables, readonly properties, wrong ORM attribute typo, redundant null-coalescing)
- **Tests**: migrate PHPUnit to attribute-based data providers; add/extend unit tests for controllers, services, repositories, traits, event subscribers and state providers
- **feat(ng-settings)**: Tests and fixes for new `GET /{code}/front/configuration` endpoint returning the ng frontend configuration (menu, theme, homepage, statistics, languages) from `JOURNAL_SETTING`; includes entity, repository, state provider and unit tests

## Test plan

- [ ] `make docker-test` — full PHPUnit suite passes
- [ ] `make phpstan` — 0 errors at level 1
- [ ] `GET /{code}/front/configuration` returns the expected JSON for a journal with settings
- [ ] `GET /{code}/front/configuration` returns 404 for unknown journal code
- [ ] `GET /{code}/front/configuration` returns 404 when no settings row exists for the journal