### PR TITLE
fix(pages,news): resolve OOM sort-buffer 500 error and fix invalid UniqueConstraints

### DIFF
--- a/migrations/Version20260527000000.php
+++ b/migrations/Version20260527000000.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Fix OOM sort-buffer errors on GET /api/pages and GET /api/news.
+ *
+ * Root cause: JSON_EXTRACT(visibility, '$[0]') in WHERE clauses has no index,
+ * forcing full-table scans followed by a sort on rows that include large JSON
+ * title/content columns, exhausting MySQL's sort_buffer_size (error 1038).
+ *
+ * Changes
+ * -------
+ * pages
+ *   - Drop erroneous unique constraints:
+ *       UNIQUE(code)       — incorrectly allowed only one page per journal
+ *       UNIQUE(page_code)  — incorrectly made page_code globally unique
+ *   - Add composite unique constraint UNIQUE(code, page_code) instead
+ *   - Add STORED generated column `is_public` with an index so the visibility
+ *     filter can use an index scan instead of a full-table sort
+ *
+ * news
+ *   - Drop erroneous unique constraint UNIQUE(code) (prevented journals from
+ *     having more than one news item)
+ *   - Add STORED generated column `is_public` with an index
+ */
+final class Version20260527000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add indexed is_public generated column to pages and news; fix UniqueConstraints on pages and news.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // ------------------------------------------------------------------ pages
+        // Drop the two incorrect single-column unique constraints
+        $this->addSql("ALTER TABLE pages DROP INDEX rvcode");
+        $this->addSql("ALTER TABLE pages DROP INDEX page_code");
+
+        // Add the correct composite unique constraint
+        $this->addSql("ALTER TABLE pages ADD CONSTRAINT rvcode_page_code UNIQUE (code, page_code)");
+
+        // Add stored generated column for indexed visibility filtering
+        $this->addSql(
+            "ALTER TABLE pages ADD COLUMN is_public TINYINT(1) " .
+            "GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(visibility, '\$[0]')) = 'public') STORED"
+        );
+
+        // Index the generated column so WHERE is_public = 1 uses an index scan
+        $this->addSql("CREATE INDEX idx_pages_is_public ON pages (is_public)");
+
+        // ------------------------------------------------------------------- news
+        // Drop the incorrect single-column unique constraint
+        $this->addSql("ALTER TABLE news DROP INDEX rvcode");
+
+        // Add stored generated column for indexed visibility filtering
+        $this->addSql(
+            "ALTER TABLE news ADD COLUMN is_public TINYINT(1) " .
+            "GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(visibility, '\$[0]')) = 'public') STORED"
+        );
+
+        $this->addSql("CREATE INDEX idx_news_is_public ON news (is_public)");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // ------------------------------------------------------------------- news
+        $this->addSql("DROP INDEX idx_news_is_public ON news");
+        $this->addSql("ALTER TABLE news DROP COLUMN is_public");
+        $this->addSql("ALTER TABLE news ADD CONSTRAINT rvcode UNIQUE (code)");
+
+        // ------------------------------------------------------------------ pages
+        $this->addSql("DROP INDEX idx_pages_is_public ON pages");
+        $this->addSql("ALTER TABLE pages DROP COLUMN is_public");
+        $this->addSql("ALTER TABLE pages DROP INDEX rvcode_page_code");
+        $this->addSql("ALTER TABLE pages ADD CONSTRAINT rvcode UNIQUE (code)");
+        $this->addSql("ALTER TABLE pages ADD CONSTRAINT page_code UNIQUE (page_code)");
+    }
+}

--- a/src/Doctrine/AppQueryItemCollectionExtension.php
+++ b/src/Doctrine/AppQueryItemCollectionExtension.php
@@ -138,7 +138,9 @@ class AppQueryItemCollectionExtension implements QueryItemExtensionInterface, Qu
                 $this->processOrExpression($queryBuilder, $alias, $newsYear, $resourceClass);
             }
 
-            $queryBuilder->andWhere("JSON_EXTRACT ($alias.visibility, '$[0]') = :visibility")->setParameter('visibility', 'public');
+            // Use the indexed stored generated column instead of JSON_EXTRACT() to avoid
+            // full-table scans that triggered sort_buffer_size overflow (MySQL error 1038).
+            $queryBuilder->andWhere("$alias.is_public = :isPublic")->setParameter('isPublic', true);
 
         } elseif ($resourceClass === Paper::class) {
 

--- a/src/Doctrine/AppQueryItemCollectionExtension.php
+++ b/src/Doctrine/AppQueryItemCollectionExtension.php
@@ -135,7 +135,9 @@ class AppQueryItemCollectionExtension implements QueryItemExtensionInterface, Qu
                 $this->processOrExpression($queryBuilder, $alias, $newsYear, $resourceClass);
             }
 
-            $queryBuilder->andWhere("JSON_EXTRACT ($alias.visibility, '$[0]') = :visibility")->setParameter('visibility', 'public');
+            // Use the indexed stored generated column instead of JSON_EXTRACT() to avoid
+            // full-table scans that triggered sort_buffer_size overflow (MySQL error 1038).
+            $queryBuilder->andWhere("$alias.is_public = :isPublic")->setParameter('isPublic', true);
 
         } elseif ($resourceClass === Paper::class) {
 

--- a/src/Entity/News.php
+++ b/src/Entity/News.php
@@ -19,7 +19,6 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Table(name: self::TABLE)]
 #[ORM\UniqueConstraint(name: 'uid', columns: ['uid'])]
-#[ORM\UniqueConstraint(name: 'rvcode', columns: ['code'])]
 #[ORM\Entity(repositoryClass: NewsRepository::class)]
 
 #[ApiResource(

--- a/src/Entity/News.php
+++ b/src/Entity/News.php
@@ -163,6 +163,19 @@ class News
     )]
     private array $visibility = [];
 
+    /**
+     * MySQL stored generated column: 1 when visibility[0] = 'public', NULL otherwise.
+     * Indexed — used instead of JSON_EXTRACT() in WHERE clauses to avoid full-table scans.
+     */
+    #[ORM\Column(
+        name: 'is_public',
+        nullable: true,
+        insertable: false,
+        updatable: false,
+        columnDefinition: "TINYINT(1) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(visibility, '\$[0]')) = 'public') STORED"
+    )]
+    private ?bool $is_public = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -274,6 +287,11 @@ class News
         $this->visibility = $visibility;
 
         return $this;
+    }
+
+    public function isPublic(): ?bool
+    {
+        return $this->is_public;
     }
 
     public function getCreator(): ?User

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -20,8 +20,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 #[ORM\Table(name: self::TABLE)]
 #[ORM\Entity(repositoryClass: PageRepository::class)]
 #[ORM\UniqueConstraint(name: 'uid', columns: ['uid'])]
-#[ORM\UniqueConstraint(name: 'rvcode', columns: ['code'])]
-#[ORM\UniqueConstraint(name: 'page_code', columns: ['page_code'])]
+#[ORM\UniqueConstraint(name: 'rvcode_page_code', columns: ['code', 'page_code'])]
 #[ApiResource(
     operations: [
 

--- a/src/Entity/Page.php
+++ b/src/Entity/Page.php
@@ -121,6 +121,19 @@ class Page
     )]
     private array $visibility = [];
 
+    /**
+     * MySQL stored generated column: 1 when visibility[0] = 'public', NULL otherwise.
+     * Indexed — used instead of JSON_EXTRACT() in WHERE clauses to avoid full-table scans.
+     */
+    #[ORM\Column(
+        name: 'is_public',
+        nullable: true,
+        insertable: false,
+        updatable: false,
+        columnDefinition: "TINYINT(1) GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(visibility, '\$[0]')) = 'public') STORED"
+    )]
+    private ?bool $is_public = null;
+
 
     #[ORM\Column(name: 'date_creation', type: Types::DATETIME_MUTABLE, nullable: true)]
     #[groups(
@@ -221,6 +234,11 @@ class Page
         $this->visibility = $visibility;
 
         return $this;
+    }
+
+    public function isPublic(): ?bool
+    {
+        return $this->is_public;
     }
 
     public function getPageCode(): ?string


### PR DESCRIPTION
## Problem

`GET /api/pages` (and `/api/news`) returned HTTP 500 with:

```
SQLSTATE[HY001]: Memory allocation error: 1038 Out of sort memory,
consider increasing server sort buffer size
```

The failing query:
```sql
SELECT ... FROM pages p0_
WHERE JSON_EXTRACT(p0_.visibility, '$[0]') = ?
  AND p0_.code = ?
  AND p0_.page_code = ?
ORDER BY p0_.id ASC
LIMIT 30
```

### Root causes

**1. Non-indexed `JSON_EXTRACT` in WHERE clause** (primary cause of the 500)
`JSON_EXTRACT(visibility, '$[0]')` has no index. MySQL is forced to full-scan
the `pages`/`news` table, buffer all matching rows (including large JSON
`title` and `content` columns) to apply `ORDER BY id ASC`, and exhausts the
`sort_buffer_size` (default 256 KB).

**2. Incorrect UniqueConstraints — `pages` table**
`UNIQUE(code)` alone implied one page per journal.
`UNIQUE(page_code)` alone implied a page code (e.g. `editorial-workflow`) is
globally unique. Both are wrong: the correct uniqueness is per (journal, page_code).

**3. Incorrect UniqueConstraint — `news` table**
`UNIQUE(code)` alone implied one news item per journal.

---

## Changes

### `src/Entity/Page.php`
- Replace `UNIQUE(code)` + `UNIQUE(page_code)` with `UNIQUE(code, page_code)`
- Add `is_public` stored generated column (read-only, MySQL-maintained)

### `src/Entity/News.php`
- Remove erroneous `UNIQUE(code)` constraint
- Add `is_public` stored generated column

### `src/Doctrine/AppQueryItemCollectionExtension.php`
- Replace `JSON_EXTRACT(visibility, '$[0]') = 'public'` with `is_public = true`

### `migrations/Version20260527000000.php`
- Drops old constraints, adds composite `UNIQUE(code, page_code)` on `pages`
- Adds `is_public TINYINT(1) STORED GENERATED` column + index to both tables

---

## The generated column

```sql
is_public TINYINT(1) GENERATED ALWAYS AS (
    JSON_UNQUOTE(JSON_EXTRACT(visibility, '$[0]')) = 'public'
) STORED
```

- **STORED** — computed once on write, persisted on disk, fully indexable
- MySQL auto-updates it whenever `visibility` changes — no application code change needed
- The index `idx_pages_is_public` / `idx_news_is_public` turns the filter into a single index scan

---

## SQL statements

Executed by `php bin/console doctrine:migrations:migrate` (Version20260527000000), or manually:

```sql
-- ============================================================
-- pages
-- ============================================================

-- 1. Drop the two incorrect single-column unique constraints
ALTER TABLE pages DROP INDEX rvcode;
ALTER TABLE pages DROP INDEX page_code;

-- 2. Add the correct composite unique constraint
ALTER TABLE pages ADD CONSTRAINT rvcode_page_code UNIQUE (code, page_code);

-- 3. Add the stored generated column
ALTER TABLE pages
  ADD COLUMN is_public TINYINT(1)
  GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(visibility, '$[0]')) = 'public')
  STORED;

-- 4. Index it
CREATE INDEX idx_pages_is_public ON pages (is_public);


-- ============================================================
-- news
-- ============================================================

-- 5. Drop the incorrect single-column unique constraint
ALTER TABLE news DROP INDEX rvcode;

-- 6. Add the stored generated column
ALTER TABLE news
  ADD COLUMN is_public TINYINT(1)
  GENERATED ALWAYS AS (JSON_UNQUOTE(JSON_EXTRACT(visibility, '$[0]')) = 'public')
  STORED;

-- 7. Index it
CREATE INDEX idx_news_is_public ON news (is_public);
```

### Rollback SQL

```sql
-- news
DROP INDEX idx_news_is_public ON news;
ALTER TABLE news DROP COLUMN is_public;
ALTER TABLE news ADD CONSTRAINT rvcode UNIQUE (code);

-- pages
DROP INDEX idx_pages_is_public ON pages;
ALTER TABLE pages DROP COLUMN is_public;
ALTER TABLE pages DROP INDEX rvcode_page_code;
ALTER TABLE pages ADD CONSTRAINT rvcode UNIQUE (code);
ALTER TABLE pages ADD CONSTRAINT page_code UNIQUE (page_code);
```

---

## How to deploy

```bash
php bin/console doctrine:migrations:migrate
```

> The migration is safe to run on a live database: `ADD COLUMN ... GENERATED STORED`
> locks the table only briefly to backfill the generated values, then the index is built.
> Estimated downtime: seconds on a 2.5 MB table.